### PR TITLE
Safer version, roughly (but not quite) as fast

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,9 +2,16 @@
 authors = ["Andre Bogus <bogusandre@gmail.de>", "Joshua Landau <joshua@landau.ws>"]
 description = "count occurrences of a byte in a byte slice, fast"
 name = "bytecount"
-version = "0.1.3"
+version = "0.1.4"
 license = "Apache-2.0/MIT"
 repository = "https://github.com/llogiq/bytecount"
+
+[features]
+avx-accel = ["simd-accel"]
+simd-accel = ["simd"]
+
+[dependencies]
+simd = { version = "0.1.1", optional = true }
 
 [dev-dependencies]
 quickcheck = "0.3.1"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -198,5 +198,5 @@ pub fn count(haystack: &[u8], needle: u8) -> usize {
 /// assert_eq!(number_of_spaces, 6);
 /// ```
 pub fn naive_count(haystack: &[u8], needle: u8) -> usize {
-    haystack.iter().filter(|&&c| c == needle).count()
+    haystack.iter().fold(0, |n, &c| n + (c == needle) as usize)
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,32 +1,108 @@
 //! Counting occurrences of a byte in a slice
-//!
-//! There are two versions, one naive and simple (`naive_count`) and one
-//!  (`count`) that uses `unsafe`, but is hyperscreamingly fast.
-//!
-//! Usage is like you would expect (`count(haystack, needle)`).
+#[cfg(feature = "simd-accel")]
+extern crate simd;
+
 use std::{cmp, mem, slice};
 
-const LO : usize = ::std::usize::MAX / 0xFF;
-const HI : usize = LO * 128;
-const EVERY_OTHER_BYTE_LO : usize = ::std::usize::MAX / 0xFFFF;
-const EVERY_OTHER_BYTE : usize = EVERY_OTHER_BYTE_LO * 0xFF;
+#[cfg(feature = "simd-accel")]
+use simd::u8x16;
+#[cfg(feature = "avx-accel")]
+use simd::x86::sse2::Sse2U8x16;
+#[cfg(feature = "avx-accel")]
+use simd::x86::avx::{LowHigh128, u8x32};
 
-/// Count occurrences of a byte in a slice of bytes, fast
-///
-/// # Examples
-///
-/// ```
-/// let s = b"This is a Text with spaces";
-/// let number_of_spaces = bytecount::count(s, b' ');
-/// assert_eq!(number_of_spaces, 5);
-/// ```
-pub fn count(haystack: &[u8], needle: u8) -> usize {
-    let (pre, mid, post) = bytes_to_usizes(haystack);
-    naive_count(pre, needle) + usize_count(mid, needle) + naive_count(post, needle)
+
+trait ByteChunk: Copy {
+    fn splat(byte: u8) -> Self;
+    fn bytewise_equal(self, other: Self) -> Self;
+    fn increment(self, incr: Self) -> Self;
+    fn sum(self) -> usize;
 }
 
-fn bytes_to_usizes(x: &[u8]) -> (&[u8], &[[usize; 4]], &[u8]) {
-    let align = mem::size_of::<[usize; 4]>();
+impl ByteChunk for usize {
+    fn splat(byte: u8) -> Self {
+        let lo = std::usize::MAX / 0xFF;
+        lo * byte as usize
+    }
+
+    fn bytewise_equal(self, other: Self) -> Self {
+        let lo = std::usize::MAX / 0xFF;
+        let hi = lo << 7;
+
+        let x = self ^ other;
+        !((((x & !hi) + !hi) | x) >> 7) & lo
+    }
+
+    fn increment(self, incr: Self) -> Self {
+        self + incr
+    }
+
+    fn sum(self) -> usize {
+        let every_other_byte_lo = std::usize::MAX / 0xFFFF;
+        let every_other_byte = every_other_byte_lo * 0xFF;
+
+        // Pairwise reduction to avoid overflow on next step.
+        let pair_sum = (self & every_other_byte) + ((self >> 8) & every_other_byte);
+
+        // Multiplication results in top two bytes holding sum.
+        pair_sum.wrapping_mul(every_other_byte_lo) >> ((mem::size_of::<usize>() - 2) * 8)
+    }
+}
+
+#[cfg(feature = "simd-accel")]
+impl ByteChunk for u8x16 {
+    fn splat(byte: u8) -> Self {
+        Self::splat(byte)
+    }
+
+    fn bytewise_equal(self, other: Self) -> Self {
+        self.eq(other).to_repr().to_u8()
+    }
+
+    fn increment(self, incr: Self) -> Self {
+        // incr on -1
+        self - incr
+    }
+
+    fn sum(self) -> usize {
+        let mut count = 0;
+        for i in 0..16 {
+            count += self.extract(i) as usize;
+        }
+        count
+    }
+}
+
+#[cfg(feature = "avx-accel")]
+impl ByteChunk for u8x32 {
+    fn splat(byte: u8) -> Self {
+        Self::splat(byte)
+    }
+
+    fn bytewise_equal(self, other: Self) -> Self {
+        self.eq(other).to_repr().to_u8()
+    }
+
+    fn increment(self, incr: Self) -> Self {
+        // incr on -1
+        self - incr
+    }
+
+    fn sum(self) -> usize {
+        let zero = u8x16::splat(0);
+        let sad_lo = self.low().sad(zero);
+        let sad_hi = self.high().sad(zero);
+
+        let mut count = 0;
+        count += (sad_lo.extract(0) + sad_lo.extract(1)) as usize;
+        count += (sad_hi.extract(0) + sad_hi.extract(1)) as usize;
+        count
+    }
+}
+
+
+fn chunk_align<Chunk: ByteChunk>(x: &[u8]) -> (&[u8], &[[Chunk; 4]], &[u8]) {
+    let align = mem::size_of::<[Chunk; 4]>();
 
     let offset_ptr = (x.as_ptr() as usize) % align;
     let offset_end = (x.as_ptr() as usize + x.len()) % align;
@@ -37,58 +113,79 @@ fn bytes_to_usizes(x: &[u8]) -> (&[u8], &[[usize; 4]], &[u8]) {
     let mid = &x[d1..d2];
     assert!(mid.len() % align == 0);
     let mid = unsafe {
-        slice::from_raw_parts(mid.as_ptr() as *const [usize; 4], mid.len() / align)
+        slice::from_raw_parts(mid.as_ptr() as *const [Chunk; 4], mid.len() / align)
     };
 
     (&x[..d1], mid, &x[d2..])
 }
 
-
-fn vector_not(x: usize) -> usize {
-    !((((x & !HI) + !HI) | x) >> 7) & LO
-}
-
-fn arr_byte_equal(mut xs: [usize; 4], needles: usize) -> [usize; 4] {
+fn arr_byte_equal<Chunk: ByteChunk>(mut xs: [Chunk; 4], needles: Chunk) -> [Chunk; 4] {
     for i in 0..4 {
-        xs[i] = vector_not(xs[i] ^ needles);
+        xs[i] = xs[i].bytewise_equal(needles);
     }
     xs
 }
 
-fn arr_add(xs: [usize; 4], ys: [usize; 4]) -> [usize; 4] {
-    [xs[0] + ys[0], xs[1] + ys[1], xs[2] + ys[2], xs[3] + ys[3]]
+fn arr_incr<Chunk: ByteChunk>(xs: [Chunk; 4], ys: [Chunk; 4]) -> [Chunk; 4] {
+    [
+        xs[0].increment(ys[0]),
+        xs[1].increment(ys[1]),
+        xs[2].increment(ys[2]),
+        xs[3].increment(ys[3])
+    ]
 }
 
-
-fn sum_bytes(counts: usize) -> usize {
-    // Pairwise reduction to avoid overflow on next step.
-    let pair_sum = (counts & EVERY_OTHER_BYTE) + ((counts >> 8) & EVERY_OTHER_BYTE);
-
-    // Multiplication results in top two bytes holding sum.
-    pair_sum.wrapping_mul(EVERY_OTHER_BYTE_LO) >> ((mem::size_of::<usize>() - 2) * 8)
-}
-
-
-fn usize_count(haystack: &[[usize; 4]], needle: u8) -> usize {
-    let needles = needle as usize * LO;
+fn chunk_count<Chunk: ByteChunk>(haystack: &[[Chunk; 4]], needle: u8) -> usize {
+    let zero = Chunk::splat(0);
+    let needles = Chunk::splat(needle);
     let mut count = 0;
     let mut i = 0;
 
     while i < haystack.len() {
-        let mut counts = [0, 0, 0, 0];
+        let mut counts = [zero, zero, zero, zero];
 
         let end = cmp::min(i + 255, haystack.len());
         for &c in &haystack[i..end] {
-            counts = arr_add(counts, arr_byte_equal(c, needles));
+            counts = arr_incr(counts, arr_byte_equal(c, needles));
         }
         i = end;
 
-        for &c in &counts {
-            count += sum_bytes(c);
+        for i in 0..4 {
+            count += counts[i].sum();
         }
     }
 
     count
+}
+
+fn count_generic<Chunk: ByteChunk>(haystack: &[u8], needle: u8) -> usize {
+    let (pre, mid, post) = chunk_align::<Chunk>(haystack);
+    naive_count(pre, needle) + chunk_count(mid, needle) + naive_count(post, needle)
+}
+
+
+/// Count occurrences of a byte in a slice of bytes, fast
+///
+/// # Examples
+///
+/// ```
+/// let s = b"This is a Text with spaces";
+/// let number_of_spaces = bytecount::count(s, b' ');
+/// assert_eq!(number_of_spaces, 5);
+/// ```
+#[cfg(not(feature = "simd-accel"))]
+pub fn count(haystack: &[u8], needle: u8) -> usize {
+    count_generic::<usize>(haystack, needle)
+}
+
+#[cfg(all(feature = "simd-accel", not(feature = "avx-accel")))]
+pub fn count(haystack: &[u8], needle: u8) -> usize {
+    count_generic::<u8x16>(haystack, needle)
+}
+
+#[cfg(feature = "avx-accel")]
+pub fn count(haystack: &[u8], needle: u8) -> usize {
+    count_generic::<u8x32>(haystack, needle)
 }
 
 /// Count occurrences of a byte in a slice of bytes, simple

--- a/tests/check.rs
+++ b/tests/check.rs
@@ -2,7 +2,13 @@ extern crate bytecount;
 #[macro_use] extern crate quickcheck;
 extern crate rand;
 
+use std::iter;
 use bytecount::{count, naive_count};
+use rand::Rng;
+
+fn random_bytes(len: usize) -> Vec<u8> {
+    rand::thread_rng().gen_iter::<u8>().take(len).collect::<Vec<_>>()
+}
 
 quickcheck! {
     fn check_counts_correctly(x: (Vec<u8>, u8)) -> bool {
@@ -16,6 +22,14 @@ fn check_large() {
     let haystack = vec![0u8; 10_000_000];
     assert_eq!(naive_count(&haystack, 0), count(&haystack, 0));
     assert_eq!(naive_count(&haystack, 1), count(&haystack, 1));
+}
+
+#[test]
+fn check_large_rand() {
+    let haystack = random_bytes(100_000);
+    for i in (0..255).chain(iter::once(255)) {
+        assert_eq!(naive_count(&haystack, i), count(&haystack, i));
+    }
 }
 
 #[test]


### PR DESCRIPTION
This is roughly ~10% slower with `target-cpu=native`, ~20% slower without, but has only one line of `unsafe`:

    let mid = &x[d1..d2];
    assert!(mid.len() % align == 0);
    let mid = unsafe {
        slice::from_raw_parts(mid.as_ptr() as *const [usize; 4], mid.len() / align)
    };

and is significantly shorter.

This should be *much* easier to audit for safety, and significantly easier to audit over all.

# With `target-cpu=native`

**New**

    test bench_1000000_hyper ... bench:      42,402 ns/iter (+/- 41,628)
    test bench_100000_hyper  ... bench:       4,437 ns/iter (+/- 1,522)
    test bench_10000_hyper   ... bench:         417 ns/iter (+/- 68)
    test bench_1000_hyper    ... bench:          58 ns/iter (+/- 7)
    test bench_100_hyper     ... bench:          18 ns/iter (+/- 4)
    test bench_10_hyper      ... bench:           9 ns/iter (+/- 2)
    test bench_1_hyper       ... bench:           6 ns/iter (+/- 0)
    test bench_0_hyper       ... bench:           5 ns/iter (+/- 4)

**Old**

    test bench_1000000_hyper ... bench:      40,797 ns/iter (+/- 2,888)
    test bench_100000_hyper  ... bench:       3,930 ns/iter (+/- 262)
    test bench_10000_hyper   ... bench:         387 ns/iter (+/- 16)
    test bench_1000_hyper    ... bench:          54 ns/iter (+/- 2)
    test bench_100_hyper     ... bench:          14 ns/iter (+/- 1)
    test bench_10_hyper      ... bench:           6 ns/iter (+/- 0)
    test bench_1_hyper       ... bench:           2 ns/iter (+/- 0)
    test bench_0_hyper       ... bench:           2 ns/iter (+/- 0)

# Without `target-cpu=native`

**New**

    test bench_1000000_hyper ... bench:      85,758 ns/iter (+/- 15,682)
    test bench_100000_hyper  ... bench:       8,402 ns/iter (+/- 436)
    test bench_10000_hyper   ... bench:         861 ns/iter (+/- 328)
    test bench_1000_hyper    ... bench:          72 ns/iter (+/- 18)
    test bench_100_hyper     ... bench:          20 ns/iter (+/- 1)
    test bench_10_hyper      ... bench:           8 ns/iter (+/- 1)
    test bench_1_hyper       ... bench:           5 ns/iter (+/- 1)

**Old**

    test bench_1000000_hyper ... bench:      73,232 ns/iter (+/- 12,902)
    test bench_100000_hyper  ... bench:       7,364 ns/iter (+/- 849)
    test bench_10000_hyper   ... bench:         756 ns/iter (+/- 61)
    test bench_1000_hyper    ... bench:          57 ns/iter (+/- 17)
    test bench_100_hyper     ... bench:          15 ns/iter (+/- 2)
    test bench_10_hyper      ... bench:           5 ns/iter (+/- 1)
    test bench_1_hyper       ... bench:           2 ns/iter (+/- 0)
    test bench_0_hyper       ... bench:           2 ns/iter (+/- 0)

