### PR TITLE
convert benchmarks to bluss' bencher

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,9 @@ version = "0.1.4"
 license = "Apache-2.0/MIT"
 repository = "https://github.com/llogiq/bytecount"
 
+[lib]
+bench = false
+
 [features]
 avx-accel = ["simd-accel"]
 simd-accel = ["simd"]
@@ -16,3 +19,8 @@ simd = { version = "0.1.1", optional = true }
 [dev-dependencies]
 quickcheck = "0.3.1"
 rand = "0.3.14"
+bencher = "0.1"
+
+[[bench]]
+name = "bench"
+harness = false

--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -1,6 +1,6 @@
-#![feature(test)]
 
-extern crate test;
+#[macro_use]
+extern crate bencher;
 extern crate rand;
 extern crate bytecount;
 
@@ -14,14 +14,12 @@ fn random_bytes(len: usize) -> Vec<u8> {
 
 macro_rules! bench {
     ($i: expr, $name_naive: ident, $name_hyper: ident) => {
-        #[bench]
-        fn $name_naive(b: &mut test::Bencher) {
+        fn $name_naive(b: &mut bencher::Bencher) {
             let haystack = random_bytes($i);
             b.iter(|| naive_count(&haystack, 10));
         }
 
-        #[bench]
-        fn $name_hyper(b: &mut test::Bencher) {
+        fn $name_hyper(b: &mut bencher::Bencher) {
             let haystack = random_bytes($i);
             b.iter(|| count(&haystack, 10));
         }
@@ -36,3 +34,14 @@ bench!(1000, bench_1000_naive, bench_1000_hyper);
 bench!(10000, bench_10000_naive, bench_10000_hyper);
 bench!(100000, bench_100000_naive, bench_100000_hyper);
 bench!(1000000, bench_1000000_naive, bench_1000000_hyper);
+
+benchmark_group!(bench, bench_0_naive, bench_0_hyper,
+                        bench_1_naive, bench_1_hyper,
+                        bench_10_naive, bench_10_hyper,
+                        bench_100_naive, bench_100_hyper,
+                        bench_1000_naive, bench_1000_hyper,
+                        bench_10000_naive, bench_10000_hyper,
+                        bench_100000_naive, bench_100000_hyper,
+                        bench_1000000_naive, bench_1000000_hyper);
+                        
+benchmark_main!(bench);

--- a/src/bench.rs
+++ b/src/bench.rs
@@ -1,0 +1,1 @@
+../benches/bench.rs


### PR DESCRIPTION
There is one small hitch: it seems to search in SRC/ instead of benches/ cc @bluss

@Veedrac think we should merge this?