### PR TITLE
fixed some clippy warnings

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 authors = ["Andre Bogus <bogusandre@gmail.de>", "Joshua Landau <joshua@landau.ws>"]
 description = "count occurrences of a byte in a byte slice, fast"
 name = "bytecount"
-version = "0.1.4"
+version = "0.1.5"
 license = "Apache-2.0/MIT"
 repository = "https://github.com/llogiq/bytecount"
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -134,8 +134,8 @@ impl<T> ByteChunk for [T; 4]
     }
 
     fn bytewise_equal(mut self, needles: Self::Splat) -> Self {
-        for i in 0..4 {
-            self[i] = self[i].bytewise_equal(needles);
+        for t in self[..].iter_mut() {
+            *t = t.bytewise_equal(needles);
         }
         self
     }
@@ -148,11 +148,7 @@ impl<T> ByteChunk for [T; 4]
     }
 
     fn sum(&self) -> usize {
-        let mut count = 0;
-        for i in 0..4 {
-            count += self[i].sum();
-        }
-        count
+        self[..].iter().map(ByteChunk::sum).sum()
     }
 }
 


### PR DESCRIPTION
Clippy suggested replacing indexed loops with iterators. Benchmarking on my machine shows slightly faster execution with iterators, so let's take the suggestion. Thanks clippy! cc @Veedrac

Also I found that `haystack.iter().filter(|&&c| c == needle).count()` is a bit faster than the fold variant in our benches; but before changing that I'd like to make sure we have more realistic benchmarks w.r.t. branch misses.