### PR TITLE
Some minor style cleanup

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,7 +25,7 @@ impl ByteChunk for usize {
     type Splat = Self;
 
     fn splat(byte: u8) -> Self {
-        let lo = std::usize::MAX / 0xFF;
+        let lo = usize::MAX / 0xFF;
         lo * byte as usize
     }
 
@@ -34,7 +34,7 @@ impl ByteChunk for usize {
     }
 
     fn bytewise_equal(self, other: Self) -> Self {
-        let lo = std::usize::MAX / 0xFF;
+        let lo = usize::MAX / 0xFF;
         let hi = lo << 7;
 
         let x = self ^ other;
@@ -46,7 +46,7 @@ impl ByteChunk for usize {
     }
 
     fn sum(&self) -> usize {
-        let every_other_byte_lo = std::usize::MAX / 0xFFFF;
+        let every_other_byte_lo = usize::MAX / 0xFFFF;
         let every_other_byte = every_other_byte_lo * 0xFF;
 
         // Pairwise reduction to avoid overflow on next step.


### PR DESCRIPTION
None of this should really change anything, but in principle it could allow the compiler to optimize slightly better.  :)

More to the point, it makes better use of the standard library’s facilities for slice manipulation, which I feel makes the code clearer.  In addition, it uses the named constant `usize::MAX` in place of the `max_value` method, which makes it clearer that the value in question really is a compile-time constant.