### PR TITLE
num_chars

### DIFF
--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -5,13 +5,16 @@ extern crate bytecount;
 
 use rand::Rng;
 
-use bytecount::{count, naive_count, naive_count_32};
+use bytecount::{
+    count, naive_count, naive_count_32,
+    num_chars, naive_num_chars,
+};
 
 fn random_bytes(len: usize) -> Vec<u8> {
     rand::thread_rng().gen_iter::<u8>().take(len).collect::<Vec<_>>()
 }
 
-macro_rules! bench {
+macro_rules! bench_count {
     ($i: expr, $name_naive: ident, $name_32: ident, $name_hyper: ident) => {
         fn $name_naive(b: &mut bencher::Bencher) {
             let haystack = random_bytes($i);
@@ -30,105 +33,206 @@ macro_rules! bench {
     };
 }
 
-bench!(0, bench_00000_naive, bench_00000_32, bench_00000_hyper);
-bench!(10, bench_00010_naive, bench_00010_32, bench_00010_hyper);
-bench!(20, bench_00020_naive, bench_00020_32, bench_00020_hyper);
-bench!(30, bench_00030_naive, bench_00030_32, bench_00030_hyper);
+macro_rules! bench_num_chars {
+    ($i: expr, $name_naive: ident, $name_hyper: ident) => {
+        fn $name_naive(b: &mut bencher::Bencher) {
+            let haystack = random_bytes($i);
+            b.iter(|| naive_num_chars(&haystack));
+        }
 
-bench!(40, bench_00040_naive, bench_00040_32, bench_00040_hyper);
-bench!(50, bench_00050_naive, bench_00050_32, bench_00050_hyper);
-bench!(60, bench_00060_naive, bench_00060_32, bench_00060_hyper);
-bench!(70, bench_00070_naive, bench_00070_32, bench_00070_hyper);
-bench!(80, bench_00080_naive, bench_00080_32, bench_00080_hyper);
-bench!(90, bench_00090_naive, bench_00090_32, bench_00090_hyper);
-bench!(100, bench_00100_naive, bench_00100_32, bench_00100_hyper);
-bench!(120, bench_00120_naive, bench_00120_32, bench_00120_hyper);
-bench!(140, bench_00140_naive, bench_00140_32, bench_00140_hyper);
-bench!(170, bench_00170_naive, bench_00170_32, bench_00170_hyper);
-bench!(210, bench_00210_naive, bench_00210_32, bench_00210_hyper);
-bench!(250, bench_00250_naive, bench_00250_32, bench_00250_hyper);
-bench!(300, bench_00300_naive, bench_00300_32, bench_00300_hyper);
+        fn $name_hyper(b: &mut bencher::Bencher) {
+            let haystack = random_bytes($i);
+            b.iter(|| num_chars(&haystack));
+        }
+    };
+}
 
-bench!(400, bench_00400_naive, bench_00400_32, bench_00400_hyper);
-bench!(500, bench_00500_naive, bench_00500_32, bench_00500_hyper);
-bench!(600, bench_00600_naive, bench_00600_32, bench_00600_hyper);
-bench!(700, bench_00700_naive, bench_00700_32, bench_00700_hyper);
-bench!(800, bench_00800_naive, bench_00800_32, bench_00800_hyper);
-bench!(900, bench_00900_naive, bench_00900_32, bench_00900_hyper);
-bench!(1_000, bench_01000_naive, bench_01000_32, bench_01000_hyper);
-bench!(1_200, bench_01200_naive, bench_01200_32, bench_01200_hyper);
-bench!(1_400, bench_01400_naive, bench_01400_32, bench_01400_hyper);
-bench!(1_700, bench_01700_naive, bench_01700_32, bench_01700_hyper);
-bench!(2_100, bench_02100_naive, bench_02100_32, bench_02100_hyper);
-bench!(2_500, bench_02500_naive, bench_02500_32, bench_02500_hyper);
-bench!(3_000, bench_03000_naive, bench_03000_32, bench_03000_hyper);
+bench_count!(0, bench_count_00000_naive, bench_count_00000_32, bench_count_00000_hyper);
+bench_count!(10, bench_count_00010_naive, bench_count_00010_32, bench_count_00010_hyper);
+bench_count!(20, bench_count_00020_naive, bench_count_00020_32, bench_count_00020_hyper);
+bench_count!(30, bench_count_00030_naive, bench_count_00030_32, bench_count_00030_hyper);
 
-bench!(4_000, bench_04000_naive, bench_04000_32, bench_04000_hyper);
-bench!(5_000, bench_05000_naive, bench_05000_32, bench_05000_hyper);
-bench!(6_000, bench_06000_naive, bench_06000_32, bench_06000_hyper);
-bench!(7_000, bench_07000_naive, bench_07000_32, bench_07000_hyper);
-bench!(8_000, bench_08000_naive, bench_08000_32, bench_08000_hyper);
-bench!(9_000, bench_09000_naive, bench_09000_32, bench_09000_hyper);
-bench!(10_000, bench_10000_naive, bench_10000_32, bench_10000_hyper);
-bench!(12_000, bench_12000_naive, bench_12000_32, bench_12000_hyper);
-bench!(14_000, bench_14000_naive, bench_14000_32, bench_14000_hyper);
-bench!(17_000, bench_17000_naive, bench_17000_32, bench_17000_hyper);
-bench!(21_000, bench_21000_naive, bench_21000_32, bench_21000_hyper);
-bench!(25_000, bench_25000_naive, bench_25000_32, bench_25000_hyper);
-bench!(30_000, bench_30000_naive, bench_30000_32, bench_30000_hyper);
+bench_count!(40, bench_count_00040_naive, bench_count_00040_32, bench_count_00040_hyper);
+bench_count!(50, bench_count_00050_naive, bench_count_00050_32, bench_count_00050_hyper);
+bench_count!(60, bench_count_00060_naive, bench_count_00060_32, bench_count_00060_hyper);
+bench_count!(70, bench_count_00070_naive, bench_count_00070_32, bench_count_00070_hyper);
+bench_count!(80, bench_count_00080_naive, bench_count_00080_32, bench_count_00080_hyper);
+bench_count!(90, bench_count_00090_naive, bench_count_00090_32, bench_count_00090_hyper);
+bench_count!(100, bench_count_00100_naive, bench_count_00100_32, bench_count_00100_hyper);
+bench_count!(120, bench_count_00120_naive, bench_count_00120_32, bench_count_00120_hyper);
+bench_count!(140, bench_count_00140_naive, bench_count_00140_32, bench_count_00140_hyper);
+bench_count!(170, bench_count_00170_naive, bench_count_00170_32, bench_count_00170_hyper);
+bench_count!(210, bench_count_00210_naive, bench_count_00210_32, bench_count_00210_hyper);
+bench_count!(250, bench_count_00250_naive, bench_count_00250_32, bench_count_00250_hyper);
+bench_count!(300, bench_count_00300_naive, bench_count_00300_32, bench_count_00300_hyper);
 
-bench!(100_000, bench_big_0100000_naive, bench_big_0100000_32, bench_big_0100000_hyper);
-bench!(1_000_000, bench_big_1000000_naive, bench_big_1000000_32, bench_big_1000000_hyper);
+bench_count!(400, bench_count_00400_naive, bench_count_00400_32, bench_count_00400_hyper);
+bench_count!(500, bench_count_00500_naive, bench_count_00500_32, bench_count_00500_hyper);
+bench_count!(600, bench_count_00600_naive, bench_count_00600_32, bench_count_00600_hyper);
+bench_count!(700, bench_count_00700_naive, bench_count_00700_32, bench_count_00700_hyper);
+bench_count!(800, bench_count_00800_naive, bench_count_00800_32, bench_count_00800_hyper);
+bench_count!(900, bench_count_00900_naive, bench_count_00900_32, bench_count_00900_hyper);
+bench_count!(1_000, bench_count_01000_naive, bench_count_01000_32, bench_count_01000_hyper);
+bench_count!(1_200, bench_count_01200_naive, bench_count_01200_32, bench_count_01200_hyper);
+bench_count!(1_400, bench_count_01400_naive, bench_count_01400_32, bench_count_01400_hyper);
+bench_count!(1_700, bench_count_01700_naive, bench_count_01700_32, bench_count_01700_hyper);
+bench_count!(2_100, bench_count_02100_naive, bench_count_02100_32, bench_count_02100_hyper);
+bench_count!(2_500, bench_count_02500_naive, bench_count_02500_32, bench_count_02500_hyper);
+bench_count!(3_000, bench_count_03000_naive, bench_count_03000_32, bench_count_03000_hyper);
 
-benchmark_group!(bench,
-    bench_00000_naive, bench_00000_32, bench_00000_hyper,
-    bench_00010_naive, bench_00010_32, bench_00010_hyper,
-    bench_00020_naive, bench_00020_32, bench_00020_hyper,
-    bench_00030_naive, bench_00030_32, bench_00030_hyper,
+bench_count!(4_000, bench_count_04000_naive, bench_count_04000_32, bench_count_04000_hyper);
+bench_count!(5_000, bench_count_05000_naive, bench_count_05000_32, bench_count_05000_hyper);
+bench_count!(6_000, bench_count_06000_naive, bench_count_06000_32, bench_count_06000_hyper);
+bench_count!(7_000, bench_count_07000_naive, bench_count_07000_32, bench_count_07000_hyper);
+bench_count!(8_000, bench_count_08000_naive, bench_count_08000_32, bench_count_08000_hyper);
+bench_count!(9_000, bench_count_09000_naive, bench_count_09000_32, bench_count_09000_hyper);
+bench_count!(10_000, bench_count_10000_naive, bench_count_10000_32, bench_count_10000_hyper);
+bench_count!(12_000, bench_count_12000_naive, bench_count_12000_32, bench_count_12000_hyper);
+bench_count!(14_000, bench_count_14000_naive, bench_count_14000_32, bench_count_14000_hyper);
+bench_count!(17_000, bench_count_17000_naive, bench_count_17000_32, bench_count_17000_hyper);
+bench_count!(21_000, bench_count_21000_naive, bench_count_21000_32, bench_count_21000_hyper);
+bench_count!(25_000, bench_count_25000_naive, bench_count_25000_32, bench_count_25000_hyper);
+bench_count!(30_000, bench_count_30000_naive, bench_count_30000_32, bench_count_30000_hyper);
 
-    bench_00040_naive, bench_00040_32, bench_00040_hyper,
-    bench_00050_naive, bench_00050_32, bench_00050_hyper,
-    bench_00060_naive, bench_00060_32, bench_00060_hyper,
-    bench_00070_naive, bench_00070_32, bench_00070_hyper,
-    bench_00080_naive, bench_00080_32, bench_00080_hyper,
-    bench_00090_naive, bench_00090_32, bench_00090_hyper,
-    bench_00100_naive, bench_00100_32, bench_00100_hyper,
-    bench_00120_naive, bench_00120_32, bench_00120_hyper,
-    bench_00140_naive, bench_00140_32, bench_00140_hyper,
-    bench_00170_naive, bench_00170_32, bench_00170_hyper,
-    bench_00210_naive, bench_00210_32, bench_00210_hyper,
-    bench_00250_naive, bench_00250_32, bench_00250_hyper,
-    bench_00300_naive, bench_00300_32, bench_00300_hyper,
+bench_count!(100_000, bench_count_big_0100000_naive, bench_count_big_0100000_32, bench_count_big_0100000_hyper);
+bench_count!(1_000_000, bench_count_big_1000000_naive, bench_count_big_1000000_32, bench_count_big_1000000_hyper);
 
-    bench_00400_naive, bench_00400_32, bench_00400_hyper,
-    bench_00500_naive, bench_00500_32, bench_00500_hyper,
-    bench_00600_naive, bench_00600_32, bench_00600_hyper,
-    bench_00700_naive, bench_00700_32, bench_00700_hyper,
-    bench_00800_naive, bench_00800_32, bench_00800_hyper,
-    bench_00900_naive, bench_00900_32, bench_00900_hyper,
-    bench_01000_naive, bench_01000_32, bench_01000_hyper,
-    bench_01200_naive, bench_01200_32, bench_01200_hyper,
-    bench_01400_naive, bench_01400_32, bench_01400_hyper,
-    bench_01700_naive, bench_01700_32, bench_01700_hyper,
-    bench_02100_naive, bench_02100_32, bench_02100_hyper,
-    bench_02500_naive, bench_02500_32, bench_02500_hyper,
-    bench_03000_naive, bench_03000_32, bench_03000_hyper,
+benchmark_group!(bench_count_naive,
+    bench_count_00000_naive, bench_count_00010_naive, bench_count_00020_naive,
+    bench_count_00030_naive, bench_count_00040_naive, bench_count_00050_naive,
+    bench_count_00060_naive, bench_count_00070_naive, bench_count_00080_naive,
+    bench_count_00090_naive, bench_count_00100_naive, bench_count_00120_naive,
+    bench_count_00140_naive, bench_count_00170_naive, bench_count_00210_naive,
+    bench_count_00250_naive, bench_count_00300_naive, bench_count_00400_naive,
+    bench_count_00500_naive, bench_count_00600_naive, bench_count_00700_naive,
+    bench_count_00800_naive, bench_count_00900_naive, bench_count_01000_naive,
+    bench_count_01200_naive, bench_count_01400_naive, bench_count_01700_naive,
+    bench_count_02100_naive, bench_count_02500_naive, bench_count_03000_naive,
+    bench_count_04000_naive, bench_count_05000_naive, bench_count_06000_naive,
+    bench_count_07000_naive, bench_count_08000_naive, bench_count_09000_naive,
+    bench_count_10000_naive, bench_count_12000_naive, bench_count_14000_naive,
+    bench_count_17000_naive, bench_count_21000_naive, bench_count_25000_naive,
+    bench_count_30000_naive, bench_count_big_0100000_naive, bench_count_big_1000000_naive);
 
-    bench_04000_naive, bench_04000_32, bench_04000_hyper,
-    bench_05000_naive, bench_05000_32, bench_05000_hyper,
-    bench_06000_naive, bench_06000_32, bench_06000_hyper,
-    bench_07000_naive, bench_07000_32, bench_07000_hyper,
-    bench_08000_naive, bench_08000_32, bench_08000_hyper,
-    bench_09000_naive, bench_09000_32, bench_09000_hyper,
-    bench_10000_naive, bench_10000_32, bench_10000_hyper,
-    bench_12000_naive, bench_12000_32, bench_12000_hyper,
-    bench_14000_naive, bench_14000_32, bench_14000_hyper,
-    bench_17000_naive, bench_17000_32, bench_17000_hyper,
-    bench_21000_naive, bench_21000_32, bench_21000_hyper,
-    bench_25000_naive, bench_25000_32, bench_25000_hyper,
-    bench_30000_naive, bench_30000_32, bench_30000_hyper,
+benchmark_group!(bench_count_32,
+    bench_count_00000_32, bench_count_00010_32, bench_count_00020_32,
+    bench_count_00030_32, bench_count_00040_32, bench_count_00050_32,
+    bench_count_00060_32, bench_count_00070_32, bench_count_00080_32,
+    bench_count_00090_32, bench_count_00100_32, bench_count_00120_32,
+    bench_count_00140_32, bench_count_00170_32, bench_count_00210_32,
+    bench_count_00250_32, bench_count_00300_32, bench_count_00400_32,
+    bench_count_00500_32, bench_count_00600_32, bench_count_00700_32,
+    bench_count_00800_32, bench_count_00900_32, bench_count_01000_32,
+    bench_count_01200_32, bench_count_01400_32, bench_count_01700_32,
+    bench_count_02100_32, bench_count_02500_32, bench_count_03000_32,
+    bench_count_04000_32, bench_count_05000_32, bench_count_06000_32,
+    bench_count_07000_32, bench_count_08000_32, bench_count_09000_32,
+    bench_count_10000_32, bench_count_12000_32, bench_count_14000_32,
+    bench_count_17000_32, bench_count_21000_32, bench_count_25000_32,
+    bench_count_30000_32, bench_count_big_0100000_32, bench_count_big_1000000_32);
 
-    bench_big_0100000_naive, bench_big_0100000_32, bench_big_0100000_hyper,
-    bench_big_1000000_naive, bench_big_1000000_32, bench_big_1000000_hyper);
+benchmark_group!(bench_count_hyper,
+    bench_count_00000_hyper, bench_count_00010_hyper, bench_count_00020_hyper,
+    bench_count_00030_hyper, bench_count_00040_hyper, bench_count_00050_hyper,
+    bench_count_00060_hyper, bench_count_00070_hyper, bench_count_00080_hyper,
+    bench_count_00090_hyper, bench_count_00100_hyper, bench_count_00120_hyper,
+    bench_count_00140_hyper, bench_count_00170_hyper, bench_count_00210_hyper,
+    bench_count_00250_hyper, bench_count_00300_hyper, bench_count_00400_hyper,
+    bench_count_00500_hyper, bench_count_00600_hyper, bench_count_00700_hyper,
+    bench_count_00800_hyper, bench_count_00900_hyper, bench_count_01000_hyper,
+    bench_count_01200_hyper, bench_count_01400_hyper, bench_count_01700_hyper,
+    bench_count_02100_hyper, bench_count_02500_hyper, bench_count_03000_hyper,
+    bench_count_04000_hyper, bench_count_05000_hyper, bench_count_06000_hyper,
+    bench_count_07000_hyper, bench_count_08000_hyper, bench_count_09000_hyper,
+    bench_count_10000_hyper, bench_count_12000_hyper, bench_count_14000_hyper,
+    bench_count_17000_hyper, bench_count_21000_hyper, bench_count_25000_hyper,
+    bench_count_30000_hyper, bench_count_big_0100000_hyper, bench_count_big_1000000_hyper);
 
-benchmark_main!(bench);
+bench_num_chars!(0, bench_num_chars_00000_naive, bench_num_chars_00000_hyper);
+bench_num_chars!(10, bench_num_chars_00010_naive, bench_num_chars_00010_hyper);
+bench_num_chars!(20, bench_num_chars_00020_naive, bench_num_chars_00020_hyper);
+bench_num_chars!(30, bench_num_chars_00030_naive, bench_num_chars_00030_hyper);
+
+bench_num_chars!(40, bench_num_chars_00040_naive, bench_num_chars_00040_hyper);
+bench_num_chars!(50, bench_num_chars_00050_naive, bench_num_chars_00050_hyper);
+bench_num_chars!(60, bench_num_chars_00060_naive, bench_num_chars_00060_hyper);
+bench_num_chars!(70, bench_num_chars_00070_naive, bench_num_chars_00070_hyper);
+bench_num_chars!(80, bench_num_chars_00080_naive, bench_num_chars_00080_hyper);
+bench_num_chars!(90, bench_num_chars_00090_naive, bench_num_chars_00090_hyper);
+bench_num_chars!(100, bench_num_chars_00100_naive, bench_num_chars_00100_hyper);
+bench_num_chars!(120, bench_num_chars_00120_naive, bench_num_chars_00120_hyper);
+bench_num_chars!(140, bench_num_chars_00140_naive, bench_num_chars_00140_hyper);
+bench_num_chars!(170, bench_num_chars_00170_naive, bench_num_chars_00170_hyper);
+bench_num_chars!(210, bench_num_chars_00210_naive, bench_num_chars_00210_hyper);
+bench_num_chars!(250, bench_num_chars_00250_naive, bench_num_chars_00250_hyper);
+bench_num_chars!(300, bench_num_chars_00300_naive, bench_num_chars_00300_hyper);
+
+bench_num_chars!(400, bench_num_chars_00400_naive, bench_num_chars_00400_hyper);
+bench_num_chars!(500, bench_num_chars_00500_naive, bench_num_chars_00500_hyper);
+bench_num_chars!(600, bench_num_chars_00600_naive, bench_num_chars_00600_hyper);
+bench_num_chars!(700, bench_num_chars_00700_naive, bench_num_chars_00700_hyper);
+bench_num_chars!(800, bench_num_chars_00800_naive, bench_num_chars_00800_hyper);
+bench_num_chars!(900, bench_num_chars_00900_naive, bench_num_chars_00900_hyper);
+bench_num_chars!(1_000, bench_num_chars_01000_naive, bench_num_chars_01000_hyper);
+bench_num_chars!(1_200, bench_num_chars_01200_naive, bench_num_chars_01200_hyper);
+bench_num_chars!(1_400, bench_num_chars_01400_naive, bench_num_chars_01400_hyper);
+bench_num_chars!(1_700, bench_num_chars_01700_naive, bench_num_chars_01700_hyper);
+bench_num_chars!(2_100, bench_num_chars_02100_naive, bench_num_chars_02100_hyper);
+bench_num_chars!(2_500, bench_num_chars_02500_naive, bench_num_chars_02500_hyper);
+bench_num_chars!(3_000, bench_num_chars_03000_naive, bench_num_chars_03000_hyper);
+
+bench_num_chars!(4_000, bench_num_chars_04000_naive, bench_num_chars_04000_hyper);
+bench_num_chars!(5_000, bench_num_chars_05000_naive, bench_num_chars_05000_hyper);
+bench_num_chars!(6_000, bench_num_chars_06000_naive, bench_num_chars_06000_hyper);
+bench_num_chars!(7_000, bench_num_chars_07000_naive, bench_num_chars_07000_hyper);
+bench_num_chars!(8_000, bench_num_chars_08000_naive, bench_num_chars_08000_hyper);
+bench_num_chars!(9_000, bench_num_chars_09000_naive, bench_num_chars_09000_hyper);
+bench_num_chars!(10_000, bench_num_chars_10000_naive, bench_num_chars_10000_hyper);
+bench_num_chars!(12_000, bench_num_chars_12000_naive, bench_num_chars_12000_hyper);
+bench_num_chars!(14_000, bench_num_chars_14000_naive, bench_num_chars_14000_hyper);
+bench_num_chars!(17_000, bench_num_chars_17000_naive, bench_num_chars_17000_hyper);
+bench_num_chars!(21_000, bench_num_chars_21000_naive, bench_num_chars_21000_hyper);
+bench_num_chars!(25_000, bench_num_chars_25000_naive, bench_num_chars_25000_hyper);
+bench_num_chars!(30_000, bench_num_chars_30000_naive, bench_num_chars_30000_hyper);
+
+bench_num_chars!(100_000, bench_num_chars_big_0100000_naive, bench_num_chars_big_0100000_hyper);
+bench_num_chars!(1_000_000, bench_num_chars_big_1000000_naive, bench_num_chars_big_1000000_hyper);
+
+benchmark_group!(bench_num_chars_naive,
+    bench_num_chars_00000_naive, bench_num_chars_00010_naive, bench_num_chars_00020_naive,
+    bench_num_chars_00030_naive, bench_num_chars_00040_naive, bench_num_chars_00050_naive,
+    bench_num_chars_00060_naive, bench_num_chars_00070_naive, bench_num_chars_00080_naive,
+    bench_num_chars_00090_naive, bench_num_chars_00100_naive, bench_num_chars_00120_naive,
+    bench_num_chars_00140_naive, bench_num_chars_00170_naive, bench_num_chars_00210_naive,
+    bench_num_chars_00250_naive, bench_num_chars_00300_naive, bench_num_chars_00400_naive,
+    bench_num_chars_00500_naive, bench_num_chars_00600_naive, bench_num_chars_00700_naive,
+    bench_num_chars_00800_naive, bench_num_chars_00900_naive, bench_num_chars_01000_naive,
+    bench_num_chars_01200_naive, bench_num_chars_01400_naive, bench_num_chars_01700_naive,
+    bench_num_chars_02100_naive, bench_num_chars_02500_naive, bench_num_chars_03000_naive,
+    bench_num_chars_04000_naive, bench_num_chars_05000_naive, bench_num_chars_06000_naive,
+    bench_num_chars_07000_naive, bench_num_chars_08000_naive, bench_num_chars_09000_naive,
+    bench_num_chars_10000_naive, bench_num_chars_12000_naive, bench_num_chars_14000_naive,
+    bench_num_chars_17000_naive, bench_num_chars_21000_naive, bench_num_chars_25000_naive,
+    bench_num_chars_30000_naive, bench_num_chars_big_0100000_naive, bench_num_chars_big_1000000_naive);
+
+benchmark_group!(bench_num_chars_hyper,
+    bench_num_chars_00000_hyper, bench_num_chars_00010_hyper, bench_num_chars_00020_hyper,
+    bench_num_chars_00030_hyper, bench_num_chars_00040_hyper, bench_num_chars_00050_hyper,
+    bench_num_chars_00060_hyper, bench_num_chars_00070_hyper, bench_num_chars_00080_hyper,
+    bench_num_chars_00090_hyper, bench_num_chars_00100_hyper, bench_num_chars_00120_hyper,
+    bench_num_chars_00140_hyper, bench_num_chars_00170_hyper, bench_num_chars_00210_hyper,
+    bench_num_chars_00250_hyper, bench_num_chars_00300_hyper, bench_num_chars_00400_hyper,
+    bench_num_chars_00500_hyper, bench_num_chars_00600_hyper, bench_num_chars_00700_hyper,
+    bench_num_chars_00800_hyper, bench_num_chars_00900_hyper, bench_num_chars_01000_hyper,
+    bench_num_chars_01200_hyper, bench_num_chars_01400_hyper, bench_num_chars_01700_hyper,
+    bench_num_chars_02100_hyper, bench_num_chars_02500_hyper, bench_num_chars_03000_hyper,
+    bench_num_chars_04000_hyper, bench_num_chars_05000_hyper, bench_num_chars_06000_hyper,
+    bench_num_chars_07000_hyper, bench_num_chars_08000_hyper, bench_num_chars_09000_hyper,
+    bench_num_chars_10000_hyper, bench_num_chars_12000_hyper, bench_num_chars_14000_hyper,
+    bench_num_chars_17000_hyper, bench_num_chars_21000_hyper, bench_num_chars_25000_hyper,
+    bench_num_chars_30000_hyper, bench_num_chars_big_0100000_hyper, bench_num_chars_big_1000000_hyper);
+
+benchmark_main!(
+    bench_count_naive, bench_count_32, bench_count_hyper,
+    bench_num_chars_naive, bench_num_chars_hyper
+);

--- a/tests/check.rs
+++ b/tests/check.rs
@@ -4,7 +4,10 @@ extern crate quickcheck;
 extern crate rand;
 
 use std::iter;
-use bytecount::{count, naive_count};
+use bytecount::{
+    count, naive_count,
+    num_chars, naive_num_chars,
+};
 use rand::Rng;
 
 fn random_bytes(len: usize) -> Vec<u8> {
@@ -12,21 +15,21 @@ fn random_bytes(len: usize) -> Vec<u8> {
 }
 
 quickcheck! {
-    fn check_counts_correctly(x: (Vec<u8>, u8)) -> bool {
+    fn check_count_correct(x: (Vec<u8>, u8)) -> bool {
         let (haystack, needle) = x;
-        count(&haystack.clone(), needle) == naive_count(&haystack, needle)
+        count(&haystack, needle) == naive_count(&haystack, needle)
     }
 }
 
 #[test]
-fn check_large() {
+fn check_count_large() {
     let haystack = vec![0u8; 10_000_000];
     assert_eq!(naive_count(&haystack, 0), count(&haystack, 0));
     assert_eq!(naive_count(&haystack, 1), count(&haystack, 1));
 }
 
 #[test]
-fn check_large_rand() {
+fn check_count_large_rand() {
     let haystack = random_bytes(100_000);
     for i in (0..255).chain(iter::once(255)) {
         assert_eq!(naive_count(&haystack, i), count(&haystack, i));
@@ -34,16 +37,40 @@ fn check_large_rand() {
 }
 
 #[test]
-fn check_some() {
+fn check_count_some() {
     let haystack = vec![0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 68];
     let needle = 68;
     assert_eq!(count(&haystack, needle), naive_count(&haystack, needle));
 }
 
 #[test]
-fn check_overflow() {
+fn check_count_overflow() {
     let haystack = vec![0, 2, 3, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0];
     let needle = 2;
-    assert_eq!(count(&haystack[0..], needle),
-               naive_count(&haystack[0..], needle));
+    assert_eq!(count(&haystack, needle), naive_count(&haystack, needle));
+}
+
+quickcheck! {
+    fn check_num_chars_correct(haystack: Vec<u8>) -> bool {
+        num_chars(&haystack) == naive_num_chars(&haystack)
+    }
+}
+
+#[test]
+fn check_num_chars_large() {
+    let haystack = vec![0u8; 10_000_000];
+    assert_eq!(naive_num_chars(&haystack), num_chars(&haystack));
+    assert_eq!(naive_num_chars(&haystack), num_chars(&haystack));
+}
+
+#[test]
+fn check_num_chars_some() {
+    let haystack = vec![0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 68];
+    assert_eq!(num_chars(&haystack), naive_num_chars(&haystack));
+}
+
+#[test]
+fn check_num_chars_overflow() {
+    let haystack = vec![0, 2, 3, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0];
+    assert_eq!(num_chars(&haystack), naive_num_chars(&haystack));
 }


### PR DESCRIPTION
No tuning has been done whatsoever. I also have only the hastiest, barest of tests.

Without SIMD

    test bench_num_chars_00000_hyper       ... bench:           3 ns/iter (+/- 0)
    test bench_num_chars_00000_naive       ... bench:           1 ns/iter (+/- 0)
    test bench_num_chars_00010_hyper       ... bench:           8 ns/iter (+/- 1)
    test bench_num_chars_00010_naive       ... bench:           6 ns/iter (+/- 0)
    test bench_num_chars_00020_hyper       ... bench:          12 ns/iter (+/- 1)
    test bench_num_chars_00020_naive       ... bench:          10 ns/iter (+/- 1)
    test bench_num_chars_00030_hyper       ... bench:          18 ns/iter (+/- 2)
    test bench_num_chars_00030_naive       ... bench:          16 ns/iter (+/- 2)
    test bench_num_chars_00040_hyper       ... bench:          14 ns/iter (+/- 2)
    test bench_num_chars_00040_naive       ... bench:          20 ns/iter (+/- 4)
    test bench_num_chars_00050_hyper       ... bench:          16 ns/iter (+/- 1)
    test bench_num_chars_00050_naive       ... bench:          25 ns/iter (+/- 3)
    test bench_num_chars_00060_hyper       ... bench:          18 ns/iter (+/- 3)
    test bench_num_chars_00060_naive       ... bench:          29 ns/iter (+/- 4)
    test bench_num_chars_00070_hyper       ... bench:          18 ns/iter (+/- 2)
    test bench_num_chars_00070_naive       ... bench:          35 ns/iter (+/- 6)
    test bench_num_chars_00080_hyper       ... bench:          16 ns/iter (+/- 1)
    test bench_num_chars_00080_naive       ... bench:          39 ns/iter (+/- 5)
    test bench_num_chars_00090_hyper       ... bench:          19 ns/iter (+/- 2)
    test bench_num_chars_00090_naive       ... bench:          45 ns/iter (+/- 7)
    test bench_num_chars_00100_hyper       ... bench:          18 ns/iter (+/- 3)
    test bench_num_chars_00100_naive       ... bench:          49 ns/iter (+/- 12)
    test bench_num_chars_00120_hyper       ... bench:          18 ns/iter (+/- 2)
    test bench_num_chars_00120_naive       ... bench:          58 ns/iter (+/- 11)
    test bench_num_chars_00140_hyper       ... bench:          21 ns/iter (+/- 2)
    test bench_num_chars_00140_naive       ... bench:          67 ns/iter (+/- 14)
    test bench_num_chars_00170_hyper       ... bench:          22 ns/iter (+/- 2)
    test bench_num_chars_00170_naive       ... bench:          81 ns/iter (+/- 19)
    test bench_num_chars_00210_hyper       ... bench:          24 ns/iter (+/- 4)
    test bench_num_chars_00210_naive       ... bench:         101 ns/iter (+/- 13)
    test bench_num_chars_00250_hyper       ... bench:          26 ns/iter (+/- 5)
    test bench_num_chars_00250_naive       ... bench:         123 ns/iter (+/- 46)
    test bench_num_chars_00300_hyper       ... bench:          28 ns/iter (+/- 5)
    test bench_num_chars_00300_naive       ... bench:         153 ns/iter (+/- 9)
    test bench_num_chars_00400_hyper       ... bench:          31 ns/iter (+/- 6)
    test bench_num_chars_00400_naive       ... bench:         199 ns/iter (+/- 30)
    test bench_num_chars_00500_hyper       ... bench:          38 ns/iter (+/- 5)
    test bench_num_chars_00500_naive       ... bench:         251 ns/iter (+/- 37)
    test bench_num_chars_00600_hyper       ... bench:          42 ns/iter (+/- 8)
    test bench_num_chars_00600_naive       ... bench:         299 ns/iter (+/- 24)
    test bench_num_chars_00700_hyper       ... bench:          47 ns/iter (+/- 7)
    test bench_num_chars_00700_naive       ... bench:         349 ns/iter (+/- 48)
    test bench_num_chars_00800_hyper       ... bench:          48 ns/iter (+/- 4)
    test bench_num_chars_00800_naive       ... bench:         387 ns/iter (+/- 43)
    test bench_num_chars_00900_hyper       ... bench:          53 ns/iter (+/- 7)
    test bench_num_chars_00900_naive       ... bench:         434 ns/iter (+/- 44)
    test bench_num_chars_01000_hyper       ... bench:          58 ns/iter (+/- 7)
    test bench_num_chars_01000_naive       ... bench:         487 ns/iter (+/- 63)
    test bench_num_chars_01200_hyper       ... bench:          67 ns/iter (+/- 9)
    test bench_num_chars_01200_naive       ... bench:         576 ns/iter (+/- 51)
    test bench_num_chars_01400_hyper       ... bench:          77 ns/iter (+/- 17)
    test bench_num_chars_01400_naive       ... bench:         670 ns/iter (+/- 61)
    test bench_num_chars_01700_hyper       ... bench:          91 ns/iter (+/- 11)
    test bench_num_chars_01700_naive       ... bench:         818 ns/iter (+/- 137)
    test bench_num_chars_02100_hyper       ... bench:         118 ns/iter (+/- 5)
    test bench_num_chars_02100_naive       ... bench:       1,001 ns/iter (+/- 183)
    test bench_num_chars_02500_hyper       ... bench:         134 ns/iter (+/- 23)
    test bench_num_chars_02500_naive       ... bench:       1,174 ns/iter (+/- 141)
    test bench_num_chars_03000_hyper       ... bench:         152 ns/iter (+/- 21)
    test bench_num_chars_03000_naive       ... bench:       1,427 ns/iter (+/- 209)
    test bench_num_chars_04000_hyper       ... bench:         202 ns/iter (+/- 29)
    test bench_num_chars_04000_naive       ... bench:       1,904 ns/iter (+/- 219)
    test bench_num_chars_05000_hyper       ... bench:         253 ns/iter (+/- 41)
    test bench_num_chars_05000_naive       ... bench:       2,383 ns/iter (+/- 343)
    test bench_num_chars_06000_hyper       ... bench:         302 ns/iter (+/- 31)
    test bench_num_chars_06000_naive       ... bench:       2,853 ns/iter (+/- 267)
    test bench_num_chars_07000_hyper       ... bench:         352 ns/iter (+/- 33)
    test bench_num_chars_07000_naive       ... bench:       3,316 ns/iter (+/- 280)
    test bench_num_chars_08000_hyper       ... bench:         400 ns/iter (+/- 58)
    test bench_num_chars_08000_naive       ... bench:       3,802 ns/iter (+/- 548)
    test bench_num_chars_09000_hyper       ... bench:         448 ns/iter (+/- 94)
    test bench_num_chars_09000_naive       ... bench:       4,281 ns/iter (+/- 870)
    test bench_num_chars_10000_hyper       ... bench:         502 ns/iter (+/- 73)
    test bench_num_chars_10000_naive       ... bench:       4,757 ns/iter (+/- 833)
    test bench_num_chars_12000_hyper       ... bench:         617 ns/iter (+/- 134)
    test bench_num_chars_12000_naive       ... bench:       5,895 ns/iter (+/- 1,022)
    test bench_num_chars_14000_hyper       ... bench:         692 ns/iter (+/- 82)
    test bench_num_chars_14000_naive       ... bench:       6,716 ns/iter (+/- 488)
    test bench_num_chars_17000_hyper       ... bench:         838 ns/iter (+/- 69)
    test bench_num_chars_17000_naive       ... bench:       8,032 ns/iter (+/- 684)
    test bench_num_chars_21000_hyper       ... bench:       1,046 ns/iter (+/- 108)
    test bench_num_chars_21000_naive       ... bench:      10,111 ns/iter (+/- 1,036)
    test bench_num_chars_25000_hyper       ... bench:       1,225 ns/iter (+/- 105)
    test bench_num_chars_25000_naive       ... bench:      11,849 ns/iter (+/- 1,386)
    test bench_num_chars_30000_hyper       ... bench:       1,458 ns/iter (+/- 246)
    test bench_num_chars_30000_naive       ... bench:      14,432 ns/iter (+/- 1,435)
    test bench_num_chars_big_0100000_hyper ... bench:       5,101 ns/iter (+/- 334)
    test bench_num_chars_big_0100000_naive ... bench:      47,379 ns/iter (+/- 3,196)
    test bench_num_chars_big_1000000_hyper ... bench:      51,260 ns/iter (+/- 6,057)
    test bench_num_chars_big_1000000_naive ... bench:     471,713 ns/iter (+/- 110,607)

SIMD

    test bench_num_chars_00000_hyper       ... bench:           5 ns/iter (+/- 1)
    test bench_num_chars_00000_naive       ... bench:           2 ns/iter (+/- 0)
    test bench_num_chars_00010_hyper       ... bench:          11 ns/iter (+/- 3)
    test bench_num_chars_00010_naive       ... bench:           8 ns/iter (+/- 2)
    test bench_num_chars_00020_hyper       ... bench:          11 ns/iter (+/- 1)
    test bench_num_chars_00020_naive       ... bench:           9 ns/iter (+/- 3)
    test bench_num_chars_00030_hyper       ... bench:          17 ns/iter (+/- 5)
    test bench_num_chars_00030_naive       ... bench:          14 ns/iter (+/- 2)
    test bench_num_chars_00040_hyper       ... bench:          19 ns/iter (+/- 2)
    test bench_num_chars_00040_naive       ... bench:          14 ns/iter (+/- 3)
    test bench_num_chars_00050_hyper       ... bench:          16 ns/iter (+/- 6)
    test bench_num_chars_00050_naive       ... bench:          15 ns/iter (+/- 8)
    test bench_num_chars_00060_hyper       ... bench:          22 ns/iter (+/- 4)
    test bench_num_chars_00060_naive       ... bench:          19 ns/iter (+/- 2)
    test bench_num_chars_00070_hyper       ... bench:          19 ns/iter (+/- 2)
    test bench_num_chars_00070_naive       ... bench:          18 ns/iter (+/- 1)
    test bench_num_chars_00080_hyper       ... bench:          16 ns/iter (+/- 1)
    test bench_num_chars_00080_naive       ... bench:          19 ns/iter (+/- 2)
    test bench_num_chars_00090_hyper       ... bench:          22 ns/iter (+/- 18)
    test bench_num_chars_00090_naive       ... bench:          24 ns/iter (+/- 1)
    test bench_num_chars_00100_hyper       ... bench:          19 ns/iter (+/- 3)
    test bench_num_chars_00100_naive       ... bench:          23 ns/iter (+/- 3)
    test bench_num_chars_00120_hyper       ... bench:          22 ns/iter (+/- 3)
    test bench_num_chars_00120_naive       ... bench:          29 ns/iter (+/- 5)
    test bench_num_chars_00140_hyper       ... bench:          23 ns/iter (+/- 1)
    test bench_num_chars_00140_naive       ... bench:          34 ns/iter (+/- 6)
    test bench_num_chars_00170_hyper       ... bench:          23 ns/iter (+/- 4)
    test bench_num_chars_00170_naive       ... bench:          39 ns/iter (+/- 4)
    test bench_num_chars_00210_hyper       ... bench:          20 ns/iter (+/- 3)
    test bench_num_chars_00210_naive       ... bench:          43 ns/iter (+/- 5)
    test bench_num_chars_00250_hyper       ... bench:          26 ns/iter (+/- 1)
    test bench_num_chars_00250_naive       ... bench:          54 ns/iter (+/- 6)
    test bench_num_chars_00300_hyper       ... bench:          28 ns/iter (+/- 3)
    test bench_num_chars_00300_naive       ... bench:          64 ns/iter (+/- 12)
    test bench_num_chars_00400_hyper       ... bench:          23 ns/iter (+/- 4)
    test bench_num_chars_00400_naive       ... bench:          78 ns/iter (+/- 7)
    test bench_num_chars_00500_hyper       ... bench:          29 ns/iter (+/- 6)
    test bench_num_chars_00500_naive       ... bench:          99 ns/iter (+/- 13)
    test bench_num_chars_00600_hyper       ... bench:          33 ns/iter (+/- 5)
    test bench_num_chars_00600_naive       ... bench:         120 ns/iter (+/- 14)
    test bench_num_chars_00700_hyper       ... bench:          39 ns/iter (+/- 8)
    test bench_num_chars_00700_naive       ... bench:         139 ns/iter (+/- 23)
    test bench_num_chars_00800_hyper       ... bench:          32 ns/iter (+/- 5)
    test bench_num_chars_00800_naive       ... bench:         155 ns/iter (+/- 30)
    test bench_num_chars_00900_hyper       ... bench:          37 ns/iter (+/- 4)
    test bench_num_chars_00900_naive       ... bench:         173 ns/iter (+/- 28)
    test bench_num_chars_01000_hyper       ... bench:          43 ns/iter (+/- 6)
    test bench_num_chars_01000_naive       ... bench:         191 ns/iter (+/- 16)
    test bench_num_chars_01200_hyper       ... bench:          42 ns/iter (+/- 5)
    test bench_num_chars_01200_naive       ... bench:         232 ns/iter (+/- 26)
    test bench_num_chars_01400_hyper       ... bench:          53 ns/iter (+/- 9)
    test bench_num_chars_01400_naive       ... bench:         268 ns/iter (+/- 31)
    test bench_num_chars_01700_hyper       ... bench:          59 ns/iter (+/- 12)
    test bench_num_chars_01700_naive       ... bench:         330 ns/iter (+/- 53)
    test bench_num_chars_02100_hyper       ... bench:          68 ns/iter (+/- 8)
    test bench_num_chars_02100_naive       ... bench:         438 ns/iter (+/- 188)
    test bench_num_chars_02500_hyper       ... bench:          78 ns/iter (+/- 3)
    test bench_num_chars_02500_naive       ... bench:         479 ns/iter (+/- 52)
    test bench_num_chars_03000_hyper       ... bench:          91 ns/iter (+/- 8)
    test bench_num_chars_03000_naive       ... bench:         572 ns/iter (+/- 76)
    test bench_num_chars_04000_hyper       ... bench:         111 ns/iter (+/- 12)
    test bench_num_chars_04000_naive       ... bench:         759 ns/iter (+/- 102)
    test bench_num_chars_05000_hyper       ... bench:         158 ns/iter (+/- 35)
    test bench_num_chars_05000_naive       ... bench:         964 ns/iter (+/- 140)
    test bench_num_chars_06000_hyper       ... bench:         198 ns/iter (+/- 74)
    test bench_num_chars_06000_naive       ... bench:       1,337 ns/iter (+/- 346)
    test bench_num_chars_07000_hyper       ... bench:         234 ns/iter (+/- 177)
    test bench_num_chars_07000_naive       ... bench:       1,590 ns/iter (+/- 421)
    test bench_num_chars_08000_hyper       ... bench:         257 ns/iter (+/- 80)
    test bench_num_chars_08000_naive       ... bench:       1,661 ns/iter (+/- 415)
    test bench_num_chars_09000_hyper       ... bench:         267 ns/iter (+/- 23)
    test bench_num_chars_09000_naive       ... bench:       1,767 ns/iter (+/- 314)
    test bench_num_chars_10000_hyper       ... bench:         285 ns/iter (+/- 25)
    test bench_num_chars_10000_naive       ... bench:       2,037 ns/iter (+/- 855)
    test bench_num_chars_12000_hyper       ... bench:         367 ns/iter (+/- 66)
    test bench_num_chars_12000_naive       ... bench:       2,434 ns/iter (+/- 341)
    test bench_num_chars_14000_hyper       ... bench:         397 ns/iter (+/- 99)
    test bench_num_chars_14000_naive       ... bench:       2,690 ns/iter (+/- 204)
    test bench_num_chars_17000_hyper       ... bench:         482 ns/iter (+/- 64)
    test bench_num_chars_17000_naive       ... bench:       3,212 ns/iter (+/- 423)
    test bench_num_chars_21000_hyper       ... bench:         571 ns/iter (+/- 77)
    test bench_num_chars_21000_naive       ... bench:       3,962 ns/iter (+/- 398)
    test bench_num_chars_25000_hyper       ... bench:         681 ns/iter (+/- 93)
    test bench_num_chars_25000_naive       ... bench:       4,708 ns/iter (+/- 434)
    test bench_num_chars_30000_hyper       ... bench:         814 ns/iter (+/- 207)
    test bench_num_chars_30000_naive       ... bench:       5,696 ns/iter (+/- 833)
    test bench_num_chars_big_0100000_hyper ... bench:       3,092 ns/iter (+/- 308)
    test bench_num_chars_big_0100000_naive ... bench:      19,066 ns/iter (+/- 1,959)
    test bench_num_chars_big_1000000_hyper ... bench:      33,375 ns/iter (+/- 14,003)
    test bench_num_chars_big_1000000_naive ... bench:     189,227 ns/iter (+/- 22,577)

AVX

    test bench_num_chars_00000_hyper       ... bench:           4 ns/iter (+/- 1)
    test bench_num_chars_00000_naive       ... bench:           2 ns/iter (+/- 0)
    test bench_num_chars_00010_hyper       ... bench:          11 ns/iter (+/- 2)
    test bench_num_chars_00010_naive       ... bench:           8 ns/iter (+/- 5)
    test bench_num_chars_00020_hyper       ... bench:          12 ns/iter (+/- 3)
    test bench_num_chars_00020_naive       ... bench:           8 ns/iter (+/- 1)
    test bench_num_chars_00030_hyper       ... bench:          16 ns/iter (+/- 1)
    test bench_num_chars_00030_naive       ... bench:          14 ns/iter (+/- 3)
    test bench_num_chars_00040_hyper       ... bench:          16 ns/iter (+/- 2)
    test bench_num_chars_00040_naive       ... bench:          14 ns/iter (+/- 2)
    test bench_num_chars_00050_hyper       ... bench:          16 ns/iter (+/- 2)
    test bench_num_chars_00050_naive       ... bench:          14 ns/iter (+/- 1)
    test bench_num_chars_00060_hyper       ... bench:          21 ns/iter (+/- 3)
    test bench_num_chars_00060_naive       ... bench:          21 ns/iter (+/- 5)
    test bench_num_chars_00070_hyper       ... bench:          17 ns/iter (+/- 3)
    test bench_num_chars_00070_naive       ... bench:          22 ns/iter (+/- 11)
    test bench_num_chars_00080_hyper       ... bench:          15 ns/iter (+/- 8)
    test bench_num_chars_00080_naive       ... bench:          21 ns/iter (+/- 5)
    test bench_num_chars_00090_hyper       ... bench:          21 ns/iter (+/- 2)
    test bench_num_chars_00090_naive       ... bench:          25 ns/iter (+/- 4)
    test bench_num_chars_00100_hyper       ... bench:          14 ns/iter (+/- 0)
    test bench_num_chars_00100_naive       ... bench:          22 ns/iter (+/- 3)
    test bench_num_chars_00120_hyper       ... bench:          20 ns/iter (+/- 2)
    test bench_num_chars_00120_naive       ... bench:          29 ns/iter (+/- 6)
    test bench_num_chars_00140_hyper       ... bench:          20 ns/iter (+/- 4)
    test bench_num_chars_00140_naive       ... bench:          34 ns/iter (+/- 5)
    test bench_num_chars_00170_hyper       ... bench:          18 ns/iter (+/- 1)
    test bench_num_chars_00170_naive       ... bench:          39 ns/iter (+/- 6)
    test bench_num_chars_00210_hyper       ... bench:          18 ns/iter (+/- 2)
    test bench_num_chars_00210_naive       ... bench:          43 ns/iter (+/- 9)
    test bench_num_chars_00250_hyper       ... bench:          23 ns/iter (+/- 3)
    test bench_num_chars_00250_naive       ... bench:          57 ns/iter (+/- 9)
    test bench_num_chars_00300_hyper       ... bench:          21 ns/iter (+/- 3)
    test bench_num_chars_00300_naive       ... bench:          64 ns/iter (+/- 11)
    test bench_num_chars_00400_hyper       ... bench:          18 ns/iter (+/- 3)
    test bench_num_chars_00400_naive       ... bench:          79 ns/iter (+/- 8)
    test bench_num_chars_00500_hyper       ... bench:          23 ns/iter (+/- 4)
    test bench_num_chars_00500_naive       ... bench:          99 ns/iter (+/- 17)
    test bench_num_chars_00600_hyper       ... bench:          26 ns/iter (+/- 5)
    test bench_num_chars_00600_naive       ... bench:         122 ns/iter (+/- 4)
    test bench_num_chars_00700_hyper       ... bench:          29 ns/iter (+/- 3)
    test bench_num_chars_00700_naive       ... bench:         140 ns/iter (+/- 22)
    test bench_num_chars_00800_hyper       ... bench:          20 ns/iter (+/- 5)
    test bench_num_chars_00800_naive       ... bench:         151 ns/iter (+/- 27)
    test bench_num_chars_00900_hyper       ... bench:          23 ns/iter (+/- 1)
    test bench_num_chars_00900_naive       ... bench:         174 ns/iter (+/- 19)
    test bench_num_chars_01000_hyper       ... bench:          27 ns/iter (+/- 5)
    test bench_num_chars_01000_naive       ... bench:         192 ns/iter (+/- 20)
    test bench_num_chars_01200_hyper       ... bench:          28 ns/iter (+/- 5)
    test bench_num_chars_01200_naive       ... bench:         230 ns/iter (+/- 24)
    test bench_num_chars_01400_hyper       ... bench:          35 ns/iter (+/- 5)
    test bench_num_chars_01400_naive       ... bench:         269 ns/iter (+/- 26)
    test bench_num_chars_01700_hyper       ... bench:          32 ns/iter (+/- 3)
    test bench_num_chars_01700_naive       ... bench:         328 ns/iter (+/- 77)
    test bench_num_chars_02100_hyper       ... bench:          41 ns/iter (+/- 8)
    test bench_num_chars_02100_naive       ... bench:         399 ns/iter (+/- 44)
    test bench_num_chars_02500_hyper       ... bench:          43 ns/iter (+/- 5)
    test bench_num_chars_02500_naive       ... bench:         479 ns/iter (+/- 50)
    test bench_num_chars_03000_hyper       ... bench:          56 ns/iter (+/- 2)
    test bench_num_chars_03000_naive       ... bench:         571 ns/iter (+/- 75)
    test bench_num_chars_04000_hyper       ... bench:          58 ns/iter (+/- 7)
    test bench_num_chars_04000_naive       ... bench:         760 ns/iter (+/- 86)
    test bench_num_chars_05000_hyper       ... bench:          79 ns/iter (+/- 15)
    test bench_num_chars_05000_naive       ... bench:         957 ns/iter (+/- 109)
    test bench_num_chars_06000_hyper       ... bench:         110 ns/iter (+/- 17)
    test bench_num_chars_06000_naive       ... bench:       1,133 ns/iter (+/- 112)
    test bench_num_chars_07000_hyper       ... bench:         122 ns/iter (+/- 14)
    test bench_num_chars_07000_naive       ... bench:       1,330 ns/iter (+/- 160)
    test bench_num_chars_08000_hyper       ... bench:         127 ns/iter (+/- 18)
    test bench_num_chars_08000_naive       ... bench:       1,510 ns/iter (+/- 201)
    test bench_num_chars_09000_hyper       ... bench:         136 ns/iter (+/- 14)
    test bench_num_chars_09000_naive       ... bench:       1,701 ns/iter (+/- 285)
    test bench_num_chars_10000_hyper       ... bench:         141 ns/iter (+/- 16)
    test bench_num_chars_10000_naive       ... bench:       1,908 ns/iter (+/- 279)
    test bench_num_chars_12000_hyper       ... bench:         180 ns/iter (+/- 30)
    test bench_num_chars_12000_naive       ... bench:       2,241 ns/iter (+/- 335)
    test bench_num_chars_14000_hyper       ... bench:         197 ns/iter (+/- 29)
    test bench_num_chars_14000_naive       ... bench:       2,788 ns/iter (+/- 500)
    test bench_num_chars_17000_hyper       ... bench:         255 ns/iter (+/- 85)
    test bench_num_chars_17000_naive       ... bench:       3,277 ns/iter (+/- 482)
    test bench_num_chars_21000_hyper       ... bench:         322 ns/iter (+/- 140)
    test bench_num_chars_21000_naive       ... bench:       3,995 ns/iter (+/- 663)
    test bench_num_chars_25000_hyper       ... bench:         355 ns/iter (+/- 60)
    test bench_num_chars_25000_naive       ... bench:       4,800 ns/iter (+/- 795)
    test bench_num_chars_30000_hyper       ... bench:         453 ns/iter (+/- 124)
    test bench_num_chars_30000_naive       ... bench:       5,901 ns/iter (+/- 1,495)
    test bench_num_chars_big_0100000_hyper ... bench:       1,589 ns/iter (+/- 167)
    test bench_num_chars_big_0100000_naive ... bench:      19,029 ns/iter (+/- 2,418)
    test bench_num_chars_big_1000000_hyper ... bench:      20,987 ns/iter (+/- 1,211)
    test bench_num_chars_big_1000000_naive ... bench:     189,939 ns/iter (+/- 16,115)
