### PR TITLE
Make sure we do not create an unaligned slice

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -188,7 +188,7 @@ fn chunk_align<Chunk: ByteChunk>(x: &[u8]) -> (&[u8], &[Chunk], &[u8]) {
     let (init, tail) = x.split_at(d2);
     let (init, mid) = init.split_at(d1);
     assert_eq!(mid.len() % align, 0);
-    // `mid` is guaranteed to be aligned
+    assert_eq!(mid.as_ptr() as usize % mem::align_of::<Chunk>(), 0, "`mid` must be aligned");
     let mid = unsafe { slice::from_raw_parts(mid.as_ptr() as *const Chunk, mid.len() / align) };
 
     (init, mid, tail)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -178,12 +178,17 @@ fn chunk_align<Chunk: ByteChunk>(x: &[u8]) -> (&[u8], &[Chunk], &[u8]) {
     let offset_ptr = (x.as_ptr() as usize) % align;
     let offset_end = (x.as_ptr() as usize + x.len()) % align;
 
+    let d1 = (align - offset_ptr) % align; // `offset_ptr` might be 0, then `d1` should be 0.
     let d2 = x.len().saturating_sub(offset_end);
-    let d1 = cmp::min((align - offset_ptr) % align, d2);
+    if d1 > d2 {
+        // No space for anything aligned
+        return (x, &[], &[]);
+    }
 
     let (init, tail) = x.split_at(d2);
     let (init, mid) = init.split_at(d1);
     assert_eq!(mid.len() % align, 0);
+    // `mid` is guaranteed to be aligned
     let mid = unsafe { slice::from_raw_parts(mid.as_ptr() as *const Chunk, mid.len() / align) };
 
     (init, mid, tail)


### PR DESCRIPTION
Based on discussion in https://github.com/rust-lang/rust/pull/52972:

References have to be always aligned. This includes `&[T]`, and it includes the case where the slice is empty. `chunk_align` was producing an unaligned `mid` part when the `cmp::min(..., d2)` picked the RHS.

So I pulled the conditional out of `cmp::min`, returning early if the slice is so short that the aligned beginning is beyond the end of the slice.