### PR TITLE
Fancy new algorithm on stable SIMD and a bunch of other stuff

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,14 @@ matrix:
     - rust: stable
       env:
         - ARCH=i686
+    - rust: stable
+      env:
+        - ARCH=i686
+        - FEATURES="--features runtime-dispatch-simd"
+    - rust: stable
+      env:
+        - ARCH=x86_64
+        - FEATURES="--features runtime-dispatch-simd"
     - rust: beta
       env:
         - ARCH=i686
@@ -26,12 +34,11 @@ matrix:
     - rust: nightly
       env:
         - ARCH=x86_64
-        - FEATURES="--features simd-accel"
+        - FEATURES="--features generic-simd"
     - rust: nightly
       env:
         - ARCH=x86_64
-        - FEATURES="--features avx-accel"
-        - RUSTFLAGS="-C target-feature=+avx"
+        - FEATURES="--features generic-simd,runtime-dispatch-simd"
 addons:
   apt:
     packages:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,12 +16,12 @@ appveyor = { repository = "llogiq/bytecount" }
 bench = false
 
 [features]
-avx-accel = ["simd-accel"]
-simd-accel = ["simd"]
+generic-simd = ["packed_simd"]
+runtime-dispatch-simd = []
 html_report = []
 
 [dependencies]
-simd = { version = "0.2.0", optional = true }
+packed_simd = { version = "0.3.0", optional = true }
 
 [dev-dependencies]
 quickcheck = "0.6"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -13,11 +13,10 @@ environment:
           CHANNEL: nightly
         - TARGET: i686-pc-windows-gnu
           CHANNEL: nightly
-          FEATURES: "--features simd-accel"
+          FEATURES: "--features generic-simd"
         - TARGET: i686-pc-windows-gnu
           CHANNEL: nightly
-          FEATURES: "--features avx-accel"
-          RUSTFLAGS: "-C target-feature=+avx"
+          FEATURES: "--features generic-simd,runtime-dispatch-simd"
         - TARGET: i686-pc-windows-msvc
           CHANNEL: stable
         - TARGET: i686-pc-windows-msvc
@@ -26,11 +25,10 @@ environment:
           CHANNEL: nightly
         - TARGET: i686-pc-windows-msvc
           CHANNEL: nightly
-          FEATURES: "--features simd-accel"
+          FEATURES: "--features generic-simd"
         - TARGET: i686-pc-windows-msvc
           CHANNEL: nightly
-          FEATURES: "--features avx-accel"
-          RUSTFLAGS: "-C target-feature=+avx"
+          FEATURES: "--features generic-simd,runtime-dispatch-simd"
         - TARGET: x86_64-pc-windows-gnu
           CHANNEL: stable
         - TARGET: x86_64-pc-windows-gnu
@@ -39,11 +37,10 @@ environment:
           CHANNEL: nightly
         - TARGET: x86_64-pc-windows-gnu
           CHANNEL: nightly
-          FEATURES: "--features simd-accel"
+          FEATURES: "--features generic-simd"
         - TARGET: x86_64-pc-windows-gnu
           CHANNEL: nightly
-          FEATURES: "--features avx-accel"
-          RUSTFLAGS: "-C target-feature=+avx"
+          FEATURES: "--features generic-simd,runtime-dispatch-simd"
         - TARGET: x86_64-pc-windows-msvc
           CHANNEL: stable
         - TARGET: x86_64-pc-windows-msvc
@@ -52,11 +49,10 @@ environment:
           CHANNEL: nightly
         - TARGET: x86_64-pc-windows-msvc
           CHANNEL: nightly
-          FEATURES: "--features simd-accel"
+          FEATURES: "--features generic-simd"
         - TARGET: x86_64-pc-windows-msvc
           CHANNEL: nightly
-          FEATURES: "--features avx-accel"
-          RUSTFLAGS: "-C target-feature=+avx"
+          FEATURES: "--features generic-simd,runtime-dispatch-simd"
 
 install:
     - curl -sSf -o rustup-init.exe https://win.rustup.rs/

--- a/src/integer_simd.rs
+++ b/src/integer_simd.rs
@@ -1,0 +1,111 @@
+#[cfg(not(feature = "runtime-dispatch-simd"))]
+use core::{mem, ptr, usize};
+#[cfg(feature = "runtime-dispatch-simd")]
+use std::{mem, ptr, usize};
+
+fn splat(byte: u8) -> usize {
+    let lo = usize::MAX / 0xFF;
+    lo * byte as usize
+}
+
+unsafe fn usize_load_unchecked(bytes: &[u8], offset: usize) -> usize {
+    let mut output = 0;
+    ptr::copy_nonoverlapping(
+        bytes.as_ptr().offset(offset as isize),
+        &mut output as *mut usize as *mut u8,
+        mem::size_of::<usize>()
+    );
+    output
+}
+
+fn bytewise_equal(lhs: usize, rhs: usize) -> usize {
+    let lo = usize::MAX / 0xFF;
+    let hi = lo << 7;
+
+    let x = lhs ^ rhs;
+    !((((x & !hi) + !hi) | x) >> 7) & lo
+}
+
+fn sum_usize(values: usize) -> usize {
+    let every_other_byte_lo = usize::MAX / 0xFFFF;
+    let every_other_byte = every_other_byte_lo * 0xFF;
+
+    // Pairwise reduction to avoid overflow on next step.
+    let pair_sum: usize = (values & every_other_byte) + ((values >> 8) & every_other_byte);
+
+    // Multiplication results in top two bytes holding sum.
+    pair_sum.wrapping_mul(every_other_byte_lo) >> ((mem::size_of::<usize>() - 2) * 8)
+}
+
+fn is_leading_utf8_byte(values: usize) -> usize {
+    // a leading UTF-8 byte is one which does not start with the bits 10.
+    ((!values >> 7) | (values >> 6)) & splat(1)
+}
+
+pub fn chunk_count(haystack: &[u8], needle: u8) -> usize {
+    let chunksize = mem::size_of::<usize>();
+    assert!(haystack.len() >= chunksize);
+
+    unsafe {
+        let mut offset = 0;
+        let mut count = 0;
+
+        let needles = splat(needle);
+
+        // 2040
+        while haystack.len() >= offset + chunksize * 255 {
+            let mut counts = 0;
+            for _ in 0..255 {
+                counts += bytewise_equal(usize_load_unchecked(haystack, offset), needles);
+                offset += chunksize;
+            }
+            count += sum_usize(counts);
+        }
+
+        // 8
+        let mut counts = 0;
+        for i in 0..(haystack.len() - offset) / chunksize {
+            counts += bytewise_equal(usize_load_unchecked(haystack, offset + i * chunksize), needles);
+        }
+        if haystack.len() % 8 != 0 {
+            let mask = !(!0 >> ((haystack.len() % chunksize) * 8));
+            counts += bytewise_equal(usize_load_unchecked(haystack, haystack.len() - chunksize), needles) & mask;
+        }
+        count += sum_usize(counts);
+
+        count
+    }
+}
+
+pub fn chunk_num_chars(utf8_chars: &[u8]) -> usize {
+    let chunksize = mem::size_of::<usize>();
+    assert!(utf8_chars.len() >= chunksize);
+
+    unsafe {
+        let mut offset = 0;
+        let mut count = 0;
+
+        // 2040
+        while utf8_chars.len() >= offset + chunksize * 255 {
+            let mut counts = 0;
+            for _ in 0..255 {
+                counts += is_leading_utf8_byte(usize_load_unchecked(utf8_chars, offset));
+                offset += chunksize;
+            }
+            count += sum_usize(counts);
+        }
+
+        // 8
+        let mut counts = 0;
+        for i in 0..(utf8_chars.len() - offset) / chunksize {
+            counts += is_leading_utf8_byte(usize_load_unchecked(utf8_chars, offset + i * chunksize));
+        }
+        if utf8_chars.len() % 8 != 0 {
+            let mask = !(!0 >> ((utf8_chars.len() % chunksize) * 8));
+            counts += is_leading_utf8_byte(usize_load_unchecked(utf8_chars, utf8_chars.len() - chunksize)) & mask;
+        }
+        count += sum_usize(counts);
+
+        count
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,10 +20,9 @@
 //! Example:
 //!
 //! ```rust
-//!# use bytecount::num_chars;
 //! let sequence = "Wenn ich ein Vöglein wär, flög ich zu Dir!";
 //! assert_eq!(sequence.chars().count(),
-//!            bytecount::num_chars(&sequence.bytes().collect::<Vec<u8>>()));
+//!            bytecount::num_chars(sequence.as_bytes()));
 //! ```
 //!
 //! For completeness and easy comparison, the "naive" versions of both
@@ -32,209 +31,24 @@
 //! [`naive_count_32`](fn.naive_count_32.html) method can be faster
 //! still on small strings.
 
-#![no_std]
-
 #![deny(missing_docs)]
 
-#[cfg(feature = "simd-accel")]
-extern crate simd;
+#![cfg_attr(not(feature = "runtime-dispatch-simd"), no_std)]
 
-use core::{cmp, mem, slice, usize};
+#[cfg(not(feature = "runtime-dispatch-simd"))]
+use core::mem;
+#[cfg(feature = "runtime-dispatch-simd")]
+use std::mem;
 
-#[cfg(feature = "simd-accel")]
-use simd::u8x16;
-#[cfg(feature = "avx-accel")]
-use simd::x86::sse2::Sse2U8x16;
-#[cfg(feature = "avx-accel")]
-use simd::x86::avx::{LowHigh128, u8x32};
+mod naive;
+pub use naive::*;
+mod integer_simd;
 
-
-trait ByteChunk: Copy {
-    type Splat: Copy;
-    fn splat(byte: u8) -> Self::Splat;
-    fn from_splat(splat: Self::Splat) -> Self;
-    fn bytewise_equal(self, other: Self::Splat) -> Self;
-    fn is_leading_utf8_byte(self) -> Self;
-    fn increment(self, incr: Self) -> Self;
-    fn sum(&self) -> usize;
-}
-
-impl ByteChunk for usize {
-    type Splat = Self;
-
-    fn splat(byte: u8) -> Self {
-        let lo = usize::MAX / 0xFF;
-        lo * byte as usize
-    }
-
-    fn from_splat(splat: Self) -> Self {
-        splat
-    }
-
-    fn is_leading_utf8_byte(self) -> Self {
-        // a leading UTF-8 byte is one which does not start with the bits 10.
-        ((!self >> 7) | (self >> 6)) & Self::splat(1)
-    }
-
-    fn bytewise_equal(self, other: Self) -> Self {
-        let lo = usize::MAX / 0xFF;
-        let hi = lo << 7;
-
-        let x = self ^ other;
-        !((((x & !hi) + !hi) | x) >> 7) & lo
-    }
-
-    fn increment(self, incr: Self) -> Self {
-        self + incr
-    }
-
-    fn sum(&self) -> usize {
-        let every_other_byte_lo = usize::MAX / 0xFFFF;
-        let every_other_byte = every_other_byte_lo * 0xFF;
-
-        // Pairwise reduction to avoid overflow on next step.
-        let pair_sum: usize = (self & every_other_byte) + ((self >> 8) & every_other_byte);
-
-        // Multiplication results in top two bytes holding sum.
-        pair_sum.wrapping_mul(every_other_byte_lo) >> ((mem::size_of::<usize>() - 2) * 8)
-    }
-}
-
-#[cfg(feature = "simd-accel")]
-impl ByteChunk for u8x16 {
-    type Splat = Self;
-
-    fn splat(byte: u8) -> Self {
-        Self::splat(byte)
-    }
-
-    fn from_splat(splat: Self) -> Self {
-        splat
-    }
-
-    fn is_leading_utf8_byte(self) -> Self {
-        (self & Self::splat(0b1100_0000)).ne(Self::splat(0b1000_0000)).to_repr().to_u8()
-    }
-
-    fn bytewise_equal(self, other: Self) -> Self {
-        self.eq(other).to_repr().to_u8()
-    }
-
-    fn increment(self, incr: Self) -> Self {
-        // incr on -1
-        self - incr
-    }
-
-    fn sum(&self) -> usize {
-        let mut count = 0;
-        for i in 0..16 {
-            count += self.extract(i) as usize;
-        }
-        count
-    }
-}
-
-#[cfg(feature = "avx-accel")]
-impl ByteChunk for u8x32 {
-    type Splat = Self;
-
-    fn splat(byte: u8) -> Self {
-        Self::splat(byte)
-    }
-
-    fn from_splat(splat: Self) -> Self {
-        splat
-    }
-
-    fn is_leading_utf8_byte(self) -> Self {
-        (self & Self::splat(0b1100_0000)).ne(Self::splat(0b1000_0000)).to_repr().to_u8()
-    }
-
-    fn bytewise_equal(self, other: Self) -> Self {
-        self.eq(other).to_repr().to_u8()
-    }
-
-    fn increment(self, incr: Self) -> Self {
-        // incr on -1
-        self - incr
-    }
-
-    fn sum(&self) -> usize {
-        let zero = u8x16::splat(0);
-        let sad_lo = self.low().sad(zero);
-        let sad_hi = self.high().sad(zero);
-
-        let mut count = 0;
-        count += (sad_lo.extract(0) + sad_lo.extract(1)) as usize;
-        count += (sad_hi.extract(0) + sad_hi.extract(1)) as usize;
-        count
-    }
-}
-
-
-fn chunk_align<Chunk: ByteChunk>(x: &[u8]) -> (&[u8], &[Chunk], &[u8]) {
-    let align = mem::size_of::<Chunk>();
-
-    let offset_ptr = (x.as_ptr() as usize) % align;
-    let offset_end = (x.as_ptr() as usize + x.len()) % align;
-
-    let d1 = (align - offset_ptr) % align; // `offset_ptr` might be 0, then `d1` should be 0.
-    let d2 = x.len().saturating_sub(offset_end);
-    if d1 > d2 {
-        // No space for anything aligned
-        return (x, &[], &[]);
-    }
-
-    let (init, tail) = x.split_at(d2);
-    let (init, mid) = init.split_at(d1);
-    assert_eq!(mid.len() % align, 0);
-    assert_eq!(mid.as_ptr() as usize % mem::align_of::<Chunk>(), 0, "`mid` must be aligned");
-    let mid = unsafe { slice::from_raw_parts(mid.as_ptr() as *const Chunk, mid.len() / align) };
-
-    (init, mid, tail)
-}
-
-fn chunk_count<Chunk: ByteChunk>(haystack: &[Chunk], needle: u8) -> usize {
-    let zero = Chunk::splat(0);
-    let needles = Chunk::splat(needle);
-    let mut count = 0;
-    let mut i = 0;
-
-    while i < haystack.len() {
-        let mut counts = Chunk::from_splat(zero);
-
-        let end = cmp::min(i + 255, haystack.len());
-        for &chunk in &haystack[i..end] {
-            counts = counts.increment(chunk.bytewise_equal(needles));
-        }
-        i = end;
-
-        count += counts.sum();
-    }
-
-    count
-}
-
-fn count_generic<Chunk: ByteChunk<Splat = Chunk>>(naive_below: usize, haystack: &[u8], needle: u8) -> usize {
-    let mut count = 0;
-
-    // Extract pre/post so naive_count is only inlined once.
-    let len = haystack.len();
-    let unchunked = if len < naive_below {
-        [haystack, &haystack[0..0]]
-    } else {
-        let (pre, mid, post) = chunk_align::<Chunk>(haystack);
-        count += chunk_count(mid, needle);
-        [pre, post]
-    };
-
-    for &slice in &unchunked {
-        count += naive_count(slice, needle);
-    }
-
-    count
-}
-
+#[cfg(any(
+    all(feature = "runtime-dispatch-simd", any(target_arch = "x86", target_arch = "x86_64")),
+    feature = "generic-simd"
+))]
+mod simd;
 
 /// Count occurrences of a byte in a slice of bytes, fast
 ///
@@ -245,116 +59,37 @@ fn count_generic<Chunk: ByteChunk<Splat = Chunk>>(naive_below: usize, haystack: 
 /// let number_of_spaces = bytecount::count(s, b' ');
 /// assert_eq!(number_of_spaces, 5);
 /// ```
-#[cfg(not(feature = "simd-accel"))]
 pub fn count(haystack: &[u8], needle: u8) -> usize {
-    count_generic::<usize>(32, haystack, needle)
-}
-
-/// Count occurrences of a byte in a slice of bytes, fast
-///
-/// # Examples
-///
-/// ```
-/// let s = b"This is a Text with spaces";
-/// let number_of_spaces = bytecount::count(s, b' ');
-/// assert_eq!(number_of_spaces, 5);
-/// ```
-#[cfg(all(feature = "simd-accel", not(feature = "avx-accel")))]
-pub fn count(haystack: &[u8], needle: u8) -> usize {
-    count_generic::<u8x16>(32, haystack, needle)
-}
-
-/// Count occurrences of a byte in a slice of bytes, fast
-///
-/// # Examples
-///
-/// ```
-/// let s = b"This is a Text with spaces";
-/// let number_of_spaces = bytecount::count(s, b' ');
-/// assert_eq!(number_of_spaces, 5);
-/// ```
-#[cfg(feature = "avx-accel")]
-pub fn count(haystack: &[u8], needle: u8) -> usize {
-    count_generic::<u8x32>(64, haystack, needle)
-}
-
-/// Count up to `(2^32)-1` occurrences of a byte in a slice
-/// of bytes, simple
-///
-/// # Example
-///
-/// ```
-/// let s = b"This is yet another Text with spaces";
-/// let number_of_spaces = bytecount::naive_count_32(s, b' ');
-/// assert_eq!(number_of_spaces, 6);
-/// ```
-pub fn naive_count_32(haystack: &[u8], needle: u8) -> usize {
-    haystack.iter().fold(0, |n, c| n + (*c == needle) as u32) as usize
-}
-
-/// Count occurrences of a byte in a slice of bytes, simple
-///
-/// # Example
-///
-/// ```
-/// let s = b"This is yet another Text with spaces";
-/// let number_of_spaces = bytecount::naive_count(s, b' ');
-/// assert_eq!(number_of_spaces, 6);
-/// ```
-pub fn naive_count(haystack: &[u8], needle: u8) -> usize {
-    haystack.iter().fold(0, |n, c| n + (*c == needle) as usize)
-}
-
-fn chunk_num_chars<Chunk: ByteChunk>(haystack: &[Chunk]) -> usize {
-    let zero = Chunk::splat(0);
-    let mut count = 0;
-    let mut i = 0;
-    while i < haystack.len() {
-        let mut counts = Chunk::from_splat(zero);
-        let end = cmp::min(i + 255, haystack.len());
-        for &chunk in &haystack[i..end] {
-            counts = counts.increment(chunk.is_leading_utf8_byte());
+    if haystack.len() >= 32 {
+        #[cfg(all(feature = "runtime-dispatch-simd", target_arch = "x86_64"))]
+        {
+            if is_x86_feature_detected!("avx2") {
+                unsafe { return simd::x86_avx2::chunk_count(haystack, needle); }
+            }
         }
-        i = end;
-        count += counts.sum();
+
+        #[cfg(feature = "generic-simd")]
+        return simd::generic::chunk_count(haystack, needle);
     }
-    count
-}
 
-fn num_chars_generic<Chunk: ByteChunk<Splat = Chunk>>(naive_below: usize, haystack: &[u8]) -> usize {
-    // Extract pre/post so naive_count is only inlined once.
-    let len = haystack.len();
-    let mut count = 0;
-    let unchunked = if len < naive_below {
-        [haystack, &haystack[0..0]]
-    } else {
-        let (pre, mid, post) = chunk_align::<Chunk>(haystack);
-        count += chunk_num_chars(mid);
-        [pre, post]
-    };
-    for &slice in &unchunked {
-        count += naive_num_chars(slice);
+    if haystack.len() >= 16 {
+        #[cfg(all(
+            feature = "runtime-dispatch-simd",
+            any(target_arch = "x86", target_arch = "x86_64"),
+            not(feature = "generic-simd")
+        ))]
+        {
+            if is_x86_feature_detected!("sse2") {
+                unsafe { return simd::x86_sse2::chunk_count(haystack, needle); }
+            }
+        }
     }
-    count
-}
 
+    if haystack.len() >= mem::size_of::<usize>() {
+        return integer_simd::chunk_count(haystack, needle);
+    }
 
-/// Count the number of UTF-8 encoded unicode codepoints in a slice of bytes, fast
-///
-/// This function is safe to use on any byte array, valid UTF-8 or not,
-/// but the output is only meaningful for well-formed UTF-8.
-///
-/// # Example
-///
-/// ```
-/// let swordfish = "メカジキ";
-/// let char_count = bytecount::num_chars(swordfish.as_bytes());
-/// assert_eq!(char_count, 4);
-/// ```
-#[cfg(not(feature = "simd-accel"))]
-pub fn num_chars(haystack: &[u8]) -> usize {
-    // Never use [usize; 4]
-    num_chars_generic::<usize>(32, haystack)
+    return naive_count(haystack, needle);
 }
 
 /// Count the number of UTF-8 encoded unicode codepoints in a slice of bytes, fast
@@ -369,40 +104,35 @@ pub fn num_chars(haystack: &[u8]) -> usize {
 /// let char_count = bytecount::num_chars(swordfish.as_bytes());
 /// assert_eq!(char_count, 4);
 /// ```
-#[cfg(all(feature = "simd-accel", not(feature = "avx-accel")))]
-pub fn num_chars(haystack: &[u8]) -> usize {
-    num_chars_generic::<u8x16>(32, haystack)
-}
+pub fn num_chars(utf8_chars: &[u8]) -> usize {
+    if utf8_chars.len() >= 32 {
+        #[cfg(all(feature = "runtime-dispatch-simd", target_arch = "x86_64"))]
+        {
+            if is_x86_feature_detected!("avx2") {
+                unsafe { return simd::x86_avx2::chunk_num_chars(utf8_chars); }
+            }
+        }
 
-/// Count the number of UTF-8 encoded unicode codepoints in a slice of bytes, fast
-///
-/// This function is safe to use on any byte array, valid UTF-8 or not,
-/// but the output is only meaningful for well-formed UTF-8.
-///
-/// # Example
-///
-/// ```
-/// let swordfish = "メカジキ";
-/// let char_count = bytecount::num_chars(swordfish.as_bytes());
-/// assert_eq!(char_count, 4);
-/// ```
-#[cfg(feature = "avx-accel")]
-pub fn num_chars(haystack: &[u8]) -> usize {
-    num_chars_generic::<u8x32>(64, haystack)
-}
+        #[cfg(feature = "generic-simd")]
+        return simd::generic::chunk_num_chars(utf8_chars);
+    }
 
-/// Count the number of UTF-8 encoded unicode codepoints in a slice of bytes, simple
-///
-/// This function is safe to use on any byte array, valid UTF-8 or not,
-/// but the output is only meaningful for well-formed UTF-8.
-///
-/// # Example
-///
-/// ```
-/// let swordfish = "メカジキ";
-/// let char_count = bytecount::naive_num_chars(swordfish.as_bytes());
-/// assert_eq!(char_count, 4);
-/// ```
-pub fn naive_num_chars(haystack: &[u8]) -> usize {
-    haystack.iter().filter(|&&byte| (byte >> 6) != 0b10).count()
+    if utf8_chars.len() >= 16 {
+        #[cfg(all(
+            feature = "runtime-dispatch-simd",
+            any(target_arch = "x86", target_arch = "x86_64"),
+            not(feature = "generic-simd")
+        ))]
+        {
+            if is_x86_feature_detected!("sse2") {
+                unsafe { return simd::x86_sse2::chunk_num_chars(utf8_chars); }
+            }
+        }
+    }
+
+    if utf8_chars.len() >= mem::size_of::<usize>() {
+        return integer_simd::chunk_num_chars(utf8_chars);
+    }
+
+    return naive_num_chars(utf8_chars);
 }

--- a/src/naive.rs
+++ b/src/naive.rs
@@ -1,0 +1,42 @@
+/// Count up to `(2^32)-1` occurrences of a byte in a slice
+/// of bytes, simple
+///
+/// # Example
+///
+/// ```
+/// let s = b"This is yet another Text with spaces";
+/// let number_of_spaces = bytecount::naive_count_32(s, b' ');
+/// assert_eq!(number_of_spaces, 6);
+/// ```
+pub fn naive_count_32(haystack: &[u8], needle: u8) -> usize {
+    haystack.iter().fold(0, |n, c| n + (*c == needle) as u32) as usize
+}
+
+/// Count occurrences of a byte in a slice of bytes, simple
+///
+/// # Example
+///
+/// ```
+/// let s = b"This is yet another Text with spaces";
+/// let number_of_spaces = bytecount::naive_count(s, b' ');
+/// assert_eq!(number_of_spaces, 6);
+/// ```
+pub fn naive_count(utf8_chars: &[u8], needle: u8) -> usize {
+    utf8_chars.iter().fold(0, |n, c| n + (*c == needle) as usize)
+}
+
+/// Count the number of UTF-8 encoded unicode codepoints in a slice of bytes, simple
+///
+/// This function is safe to use on any byte array, valid UTF-8 or not,
+/// but the output is only meaningful for well-formed UTF-8.
+///
+/// # Example
+///
+/// ```
+/// let swordfish = "メカジキ";
+/// let char_count = bytecount::naive_num_chars(swordfish.as_bytes());
+/// assert_eq!(char_count, 4);
+/// ```
+pub fn naive_num_chars(utf8_chars: &[u8]) -> usize {
+    utf8_chars.iter().filter(|&&byte| (byte >> 6) != 0b10).count()
+}

--- a/src/simd/generic.rs
+++ b/src/simd/generic.rs
@@ -1,0 +1,129 @@
+extern crate packed_simd;
+
+#[cfg(not(feature = "runtime-dispatch-simd"))]
+use core::mem;
+#[cfg(feature = "runtime-dispatch-simd")]
+use std::mem;
+
+use self::packed_simd::{u8x32, u8x64, FromCast};
+
+const MASK: [u8; 64] = [
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+    255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255,
+    255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255,
+];
+
+unsafe fn u8x64_from_offset(slice: &[u8], offset: usize) -> u8x64 {
+    u8x64::from_slice_unaligned_unchecked(slice.get_unchecked(offset..))
+}
+unsafe fn u8x32_from_offset(slice: &[u8], offset: usize) -> u8x32 {
+    u8x32::from_slice_unaligned_unchecked(slice.get_unchecked(offset..))
+}
+
+fn sum_x64(u8s: &u8x64) -> usize {
+    let mut store = [0; mem::size_of::<u8x64>()];
+    u8s.write_to_slice_unaligned(&mut store);
+    store.iter().map(|&e| e as usize).sum()
+}
+fn sum_x32(u8s: &u8x32) -> usize {
+    let mut store = [0; mem::size_of::<u8x32>()];
+    u8s.write_to_slice_unaligned(&mut store);
+    store.iter().map(|&e| e as usize).sum()
+}
+
+pub fn chunk_count(haystack: &[u8], needle: u8) -> usize {
+    assert!(haystack.len() >= 32);
+
+    unsafe {
+        let mut offset = 0;
+        let mut count = 0;
+
+        let needles_x64 = u8x64::splat(needle);
+
+        // 16320
+        while haystack.len() >= offset + 64 * 255 {
+            let mut counts = u8x64::splat(0);;
+            for _ in 0..255 {
+                counts -= u8x64::from_cast(u8x64_from_offset(haystack, offset).eq(needles_x64));
+                offset += 64;
+            }
+            count += sum_x64(&counts);
+        }
+
+        // 8192
+        if haystack.len() >= offset + 64 * 128 {
+            let mut counts = u8x64::splat(0);;
+            for _ in 0..128 {
+                counts -= u8x64::from_cast(u8x64_from_offset(haystack, offset).eq(needles_x64));
+                offset += 64;
+            }
+            count += sum_x64(&counts);
+        }
+
+        let needles_x32 = u8x32::splat(needle);
+
+        // 32
+        let mut counts = u8x32::splat(0);
+        for i in 0..(haystack.len() - offset) / 32 {
+            counts -= u8x32::from_cast(u8x32_from_offset(haystack, offset + i * 32).eq(needles_x32));
+        }
+        if haystack.len() % 32 != 0 {
+            counts -= u8x32::from_cast(u8x32_from_offset(haystack, haystack.len() - 32).eq(needles_x32)) &
+                      u8x32_from_offset(&MASK, haystack.len() % 32);
+        }
+        count += sum_x32(&counts);
+
+        count
+    }
+}
+
+fn is_leading_utf8_byte_x64(u8s: u8x64) -> u8x64 {
+    u8x64::from_cast((u8s & u8x64::splat(0b1100_0000)).ne(u8x64::splat(0b1000_0000)))
+}
+
+fn is_leading_utf8_byte_x32(u8s: u8x32) -> u8x32 {
+    u8x32::from_cast((u8s & u8x32::splat(0b1100_0000)).ne(u8x32::splat(0b1000_0000)))
+}
+
+pub fn chunk_num_chars(utf8_chars: &[u8]) -> usize {
+    assert!(utf8_chars.len() >= 32);
+
+    unsafe {
+        let mut offset = 0;
+        let mut count = 0;
+
+        // 16320
+        while utf8_chars.len() >= offset + 64 * 255 {
+            let mut counts = u8x64::splat(0);;
+            for _ in 0..255 {
+                counts -= is_leading_utf8_byte_x64(u8x64_from_offset(utf8_chars, offset));
+                offset += 64;
+            }
+            count += sum_x64(&counts);
+        }
+
+        // 8192
+        if utf8_chars.len() >= offset + 64 * 128 {
+            let mut counts = u8x64::splat(0);;
+            for _ in 0..128 {
+                counts -= is_leading_utf8_byte_x64(u8x64_from_offset(utf8_chars, offset));
+                offset += 64;
+            }
+            count += sum_x64(&counts);
+        }
+
+        // 32
+        let mut counts = u8x32::splat(0);
+        for i in 0..(utf8_chars.len() - offset) / 32 {
+            counts -= is_leading_utf8_byte_x32(u8x32_from_offset(utf8_chars, offset + i * 32));
+        }
+        if utf8_chars.len() % 32 != 0 {
+            counts -= is_leading_utf8_byte_x32(u8x32_from_offset(utf8_chars, utf8_chars.len() - 32)) &
+                      u8x32_from_offset(&MASK, utf8_chars.len() % 32);
+        }
+        count += sum_x32(&counts);
+
+        count
+    }
+}

--- a/src/simd/mod.rs
+++ b/src/simd/mod.rs
@@ -1,0 +1,17 @@
+#[cfg(feature = "generic-simd")]
+pub mod generic;
+
+// This is like generic, but written explicitly
+// because generic SIMD requires nightly.
+#[cfg(all(
+    feature = "runtime-dispatch-simd",
+    any(target_arch = "x86", target_arch = "x86_64"),
+    not(feature = "generic-simd")
+))]
+pub mod x86_sse2;
+
+// Modern x86 machines can do lots of fun stuff;
+// this is where the *real* optimizations go.
+// Runtime feature detection is not available with no_std.
+#[cfg(all(feature = "runtime-dispatch-simd", target_arch = "x86_64"))]
+pub mod x86_avx2;

--- a/src/simd/x86_avx2.rs
+++ b/src/simd/x86_avx2.rs
@@ -1,0 +1,161 @@
+use std::arch::x86_64::{
+    __m256i,
+    _mm256_and_si256,
+    _mm256_cmpeq_epi8,
+    _mm256_extract_epi64,
+    _mm256_loadu_si256,
+    _mm256_sad_epu8,
+    _mm256_set1_epi8,
+    _mm256_setzero_si256,
+    _mm256_sub_epi8,
+    _mm256_xor_si256,
+};
+
+#[target_feature(enable = "avx2")]
+pub unsafe fn _mm256_set1_epu8(a: u8) -> __m256i {
+    _mm256_set1_epi8(a as i8)
+}
+
+#[target_feature(enable = "avx2")]
+pub unsafe fn mm256_cmpneq_epi8(a: __m256i, b: __m256i) -> __m256i {
+    _mm256_xor_si256(_mm256_cmpeq_epi8(a, b), _mm256_set1_epi8(-1))
+}
+
+const MASK: [u8; 64] = [
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+    255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255,
+    255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255,
+];
+
+#[target_feature(enable = "avx2")]
+unsafe fn mm256_from_offset(slice: &[u8], offset: usize) -> __m256i {
+    _mm256_loadu_si256(slice.as_ptr().offset(offset as isize) as *const _)
+}
+
+#[target_feature(enable = "avx2")]
+unsafe fn sum(u8s: &__m256i) -> usize {
+    let sums = _mm256_sad_epu8(*u8s, _mm256_setzero_si256());
+    (
+        _mm256_extract_epi64(sums, 0) + _mm256_extract_epi64(sums, 1) +
+        _mm256_extract_epi64(sums, 2) + _mm256_extract_epi64(sums, 3)
+    ) as usize
+}
+
+#[target_feature(enable = "avx2")]
+pub unsafe fn chunk_count(haystack: &[u8], needle: u8) -> usize {
+    assert!(haystack.len() >= 32);
+
+    let mut offset = 0;
+    let mut count = 0;
+
+    let needles = _mm256_set1_epu8(needle);
+
+    // 8160
+    while haystack.len() >= offset + 32 * 255 {
+        let mut counts = _mm256_setzero_si256();
+        for _ in 0..255 {
+            counts = _mm256_sub_epi8(
+                counts,
+                _mm256_cmpeq_epi8(mm256_from_offset(haystack, offset), needles)
+            );
+            offset += 32;
+        }
+        count += sum(&counts);
+    }
+
+    // 4096
+    if haystack.len() >= offset + 32 * 128 {
+        let mut counts = _mm256_setzero_si256();
+        for _ in 0..128 {
+            counts = _mm256_sub_epi8(
+                counts,
+                _mm256_cmpeq_epi8(mm256_from_offset(haystack, offset), needles)
+            );
+            offset += 32;
+        }
+        count += sum(&counts);
+    }
+
+    // 32
+    let mut counts = _mm256_setzero_si256();
+    for i in 0..(haystack.len() - offset) / 32 {
+        counts = _mm256_sub_epi8(
+            counts,
+            _mm256_cmpeq_epi8(mm256_from_offset(haystack, offset + i * 32), needles)
+        );
+    }
+    if haystack.len() % 32 != 0 {
+        counts = _mm256_sub_epi8(
+            counts,
+            _mm256_and_si256(
+                _mm256_cmpeq_epi8(mm256_from_offset(haystack, haystack.len() - 32), needles),
+                                  mm256_from_offset(&MASK,    haystack.len() % 32)
+            )
+        );
+    }
+    count += sum(&counts);
+
+    count
+}
+
+#[target_feature(enable = "avx2")]
+unsafe fn is_leading_utf8_byte(u8s: __m256i) -> __m256i {
+    mm256_cmpneq_epi8(_mm256_and_si256(u8s, _mm256_set1_epu8(0b1100_0000)), _mm256_set1_epu8(0b1000_0000))
+}
+
+#[target_feature(enable = "avx2")]
+pub unsafe fn chunk_num_chars(utf8_chars: &[u8]) -> usize {
+    assert!(utf8_chars.len() >= 32);
+
+    let mut offset = 0;
+    let mut count = 0;
+
+    // 8160
+    while utf8_chars.len() >= offset + 32 * 255 {
+        let mut counts = _mm256_setzero_si256();
+
+        for _ in 0..255 {
+            counts = _mm256_sub_epi8(
+                counts,
+                is_leading_utf8_byte(mm256_from_offset(utf8_chars, offset))
+            );
+            offset += 32;
+        }
+        count += sum(&counts);
+    }
+
+    // 4096
+    if utf8_chars.len() >= offset + 32 * 128 {
+        let mut counts = _mm256_setzero_si256();
+        for _ in 0..128 {
+            counts = _mm256_sub_epi8(
+                counts,
+                is_leading_utf8_byte(mm256_from_offset(utf8_chars, offset))
+            );
+            offset += 32;
+        }
+        count += sum(&counts);
+    }
+
+    // 32
+    let mut counts = _mm256_setzero_si256();
+    for i in 0..(utf8_chars.len() - offset) / 32 {
+        counts = _mm256_sub_epi8(
+            counts,
+            is_leading_utf8_byte(mm256_from_offset(utf8_chars, offset + i * 32))
+        );
+    }
+    if utf8_chars.len() % 32 != 0 {
+        counts = _mm256_sub_epi8(
+            counts,
+            _mm256_and_si256(
+                is_leading_utf8_byte(mm256_from_offset(utf8_chars, utf8_chars.len() - 32)),
+                                     mm256_from_offset(&MASK,      utf8_chars.len() % 32)
+            )
+        );
+    }
+    count += sum(&counts);
+
+    count
+}

--- a/src/simd/x86_sse2.rs
+++ b/src/simd/x86_sse2.rs
@@ -1,0 +1,171 @@
+#[cfg(target_arch = "x86")]
+use std::arch::x86::{
+    __m128i,
+    _mm_and_si128,
+    _mm_cmpeq_epi8,
+    _mm_extract_epi32,
+    _mm_loadu_si128,
+    _mm_sad_epu8,
+    _mm_set1_epi8,
+    _mm_setzero_si128,
+    _mm_sub_epi8,
+    _mm_xor_si128,
+};
+
+#[cfg(target_arch = "x86_64")]
+use std::arch::x86_64::{
+    __m128i,
+    _mm_and_si128,
+    _mm_cmpeq_epi8,
+    _mm_extract_epi32,
+    _mm_loadu_si128,
+    _mm_sad_epu8,
+    _mm_set1_epi8,
+    _mm_setzero_si128,
+    _mm_sub_epi8,
+    _mm_xor_si128,
+};
+
+#[target_feature(enable = "sse2")]
+pub unsafe fn _mm_set1_epu8(a: u8) -> __m128i {
+    _mm_set1_epi8(a as i8)
+}
+
+#[target_feature(enable = "sse2")]
+pub unsafe fn mm_cmpneq_epi8(a: __m128i, b: __m128i) -> __m128i {
+    _mm_xor_si128(_mm_cmpeq_epi8(a, b), _mm_set1_epi8(-1))
+}
+
+const MASK: [u8; 32] = [
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+    255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255,
+];
+
+#[target_feature(enable = "sse2")]
+unsafe fn mm_from_offset(slice: &[u8], offset: usize) -> __m128i {
+    _mm_loadu_si128(slice.as_ptr().offset(offset as isize) as *const _)
+}
+
+#[target_feature(enable = "sse2")]
+unsafe fn sum(u8s: &__m128i) -> usize {
+    let sums = _mm_sad_epu8(*u8s, _mm_setzero_si128());
+    (_mm_extract_epi32(sums, 0) + _mm_extract_epi32(sums, 2)) as usize
+}
+
+#[target_feature(enable = "sse2")]
+pub unsafe fn chunk_count(haystack: &[u8], needle: u8) -> usize {
+    assert!(haystack.len() >= 16);
+
+    let mut offset = 0;
+    let mut count = 0;
+
+    let needles = _mm_set1_epu8(needle);
+
+    // 4080
+    while haystack.len() >= offset + 16 * 255 {
+        let mut counts = _mm_setzero_si128();
+        for _ in 0..255 {
+            counts = _mm_sub_epi8(
+                counts,
+                _mm_cmpeq_epi8(mm_from_offset(haystack, offset), needles)
+            );
+            offset += 16;
+        }
+        count += sum(&counts);
+    }
+
+    // 2048
+    if haystack.len() >= offset + 16 * 128 {
+        let mut counts = _mm_setzero_si128();
+        for _ in 0..128 {
+            counts = _mm_sub_epi8(
+                counts,
+                _mm_cmpeq_epi8(mm_from_offset(haystack, offset), needles)
+            );
+            offset += 16;
+        }
+        count += sum(&counts);
+    }
+
+    // 16
+    let mut counts = _mm_setzero_si128();
+    for i in 0..(haystack.len() - offset) / 16 {
+        counts = _mm_sub_epi8(
+            counts,
+            _mm_cmpeq_epi8(mm_from_offset(haystack, offset + i * 16), needles)
+        );
+    }
+    if haystack.len() % 16 != 0 {
+        counts = _mm_sub_epi8(
+            counts,
+            _mm_and_si128(
+                _mm_cmpeq_epi8(mm_from_offset(haystack, haystack.len() - 16), needles),
+                                  mm_from_offset(&MASK, haystack.len() % 16)
+            )
+        );
+    }
+    count += sum(&counts);
+
+    count
+}
+
+#[target_feature(enable = "sse2")]
+unsafe fn is_leading_utf8_byte(u8s: __m128i) -> __m128i {
+    mm_cmpneq_epi8(_mm_and_si128(u8s, _mm_set1_epu8(0b1100_0000)), _mm_set1_epu8(0b1000_0000))
+}
+
+#[target_feature(enable = "sse2")]
+pub unsafe fn chunk_num_chars(utf8_chars: &[u8]) -> usize {
+    assert!(utf8_chars.len() >= 16);
+
+    let mut offset = 0;
+    let mut count = 0;
+
+    // 4080
+    while utf8_chars.len() >= offset + 16 * 255 {
+        let mut counts = _mm_setzero_si128();
+
+        for _ in 0..255 {
+            counts = _mm_sub_epi8(
+                counts,
+                is_leading_utf8_byte(mm_from_offset(utf8_chars, offset))
+            );
+            offset += 16;
+        }
+        count += sum(&counts);
+    }
+
+    // 2048
+    if utf8_chars.len() >= offset + 16 * 128 {
+        let mut counts = _mm_setzero_si128();
+        for _ in 0..128 {
+            counts = _mm_sub_epi8(
+                counts,
+                is_leading_utf8_byte(mm_from_offset(utf8_chars, offset))
+            );
+            offset += 16;
+        }
+        count += sum(&counts);
+    }
+
+    // 16
+    let mut counts = _mm_setzero_si128();
+    for i in 0..(utf8_chars.len() - offset) / 16 {
+        counts = _mm_sub_epi8(
+            counts,
+            is_leading_utf8_byte(mm_from_offset(utf8_chars, offset + i * 16))
+        );
+    }
+    if utf8_chars.len() % 16 != 0 {
+        counts = _mm_sub_epi8(
+            counts,
+            _mm_and_si128(
+                is_leading_utf8_byte(mm_from_offset(utf8_chars, utf8_chars.len() - 16)),
+                                     mm_from_offset(&MASK,      utf8_chars.len() % 16)
+            )
+        );
+    }
+    count += sum(&counts);
+
+    count
+}


### PR DESCRIPTION
Sigh. I'm not a fan of Rust's fragmentation around SIMD. Let's see, we have

1. An AVX2 implementation, using Intel's intrinsics,
2. An SSE2 implementation, using Intel's intrinsics,
3. A generic version, using `packed_simd`,
4. A fake-integer-SIMD version, using bit magic,
5. A trivial fallback.

Why? Well,

1. the AVX2 implementation exists because it's the fastest,
2. the SSE2 implementation exists because the generic version requires nightly,
3. the generic version exists because other architectures exist, plus it's strictly better than the SSE2 version, plus it works with `no_std`,
4. the fake-integer-SIMD version exists for the same reason the generic one does, though it isn't as good as any of the above, but doesn't require nightly,
5. the fallback version exists for short vectors and for `naive_` operations.

If the generic version supported stable, we could throw out 2. and 4., and I could make 1. a simple extension, like it used to be. It might make sense to just throw some of this out now for maintainability reasons; this clearly isn't a sane way of doing things.

Good luck reviewing this ¬_¬. Did I mention it's all `unsafe`?
