### PR TITLE
Use inclusive range instead of chaining 255 to range.

### DIFF
--- a/tests/check.rs
+++ b/tests/check.rs
@@ -33,7 +33,7 @@ fn check_count_large() {
 #[test]
 fn check_count_large_rand() {
     let haystack = random_bytes(100_000);
-    for i in (0..255).chain(iter::once(255)) {
+    for i in 0..=255 {
         assert_eq!(naive_count(&haystack, i), count(&haystack, i));
     }
 }

--- a/tests/check.rs
+++ b/tests/check.rs
@@ -3,7 +3,6 @@ extern crate bytecount;
 extern crate quickcheck;
 extern crate rand;
 
-use std::iter;
 use bytecount::{
     count, naive_count,
     num_chars, naive_num_chars,


### PR DESCRIPTION
This was introduced in Rust 1.26, and the minimum version of v0.6 of this crate is 1.32. The change makes the test behaviour more obvious.