### PR TITLE
add Miri CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,9 @@ env:
   - FEATURES=""
 matrix:
   include:
+    - name: Miri
+      rust: nightly
+      script: ci/miri.sh
     - rust: stable
       env:
         - ARCH=i686

--- a/ci/miri.sh
+++ b/ci/miri.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+set -ex
+
+# Setup
+MIRI_NIGHTLY=nightly-$(curl -s https://rust-lang.github.io/rustup-components-history/x86_64-unknown-linux-gnu/miri)
+echo "Installing latest nightly with Miri: $MIRI_NIGHTLY"
+rustup default "$MIRI_NIGHTLY"
+rustup component add miri
+
+# Run tests
+cargo miri test
+
+# Restore old state in case Travis uses this cache for other jobs.
+rustup default nightly

--- a/ci/miri.sh
+++ b/ci/miri.sh
@@ -9,6 +9,7 @@ rustup component add miri
 
 # Run tests
 cargo miri test
+cargo miri test --target=mips64-unknown-linux-gnuabi64 # big-endian architecture
 
 # Restore old state in case Travis uses this cache for other jobs.
 rustup default nightly

--- a/tests/check.rs
+++ b/tests/check.rs
@@ -25,14 +25,14 @@ quickcheck! {
 
 #[test]
 fn check_count_large() {
-    let haystack = vec![0u8; 10_000_000];
+    let haystack = vec![0u8; if cfg!(miri) { 2_000 } else { 10_000_000 }];
     assert_eq!(naive_count(&haystack, 0), count(&haystack, 0));
     assert_eq!(naive_count(&haystack, 1), count(&haystack, 1));
 }
 
 #[test]
 fn check_count_large_rand() {
-    let haystack = random_bytes(100_000);
+    let haystack = random_bytes(if cfg!(miri) { 200 } else { 100_000 });
     for i in (0..255).chain(iter::once(255)) {
         assert_eq!(naive_count(&haystack, i), count(&haystack, i));
     }
@@ -60,7 +60,7 @@ quickcheck! {
 
 #[test]
 fn check_num_chars_large() {
-    let haystack = vec![0u8; 10_000_000];
+    let haystack = vec![0u8; if cfg!(miri) { 2_000 } else { 10_000_000 }];
     assert_eq!(naive_num_chars(&haystack), num_chars(&haystack));
     assert_eq!(naive_num_chars(&haystack), num_chars(&haystack));
 }


### PR DESCRIPTION
A long time ago, I think at RustFest Rome, we talked about using Miri to test bytecount. Back then Miri wasn't up for the task, but these days it is. :)

In the default settings, each quickcheck test takes around 50s in Miri on my machine, which seems okay. When running the tests locally, one can make things go faster with something like
```
QUICKCHECK_TESTS=10 cargo miri test -- -Zmiri-disable-isolation
```
("disable-isolation" is needed to forward the env var to the program)

Note that by default Miri makes all RNGs deterministic. We could add the `-Zmiri-disable-isolation` flag to allow seeing from the OS RNG.

Also fixes https://github.com/llogiq/bytecount/issues/53.