### PR TITLE
Use packed_simd_2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ runtime-dispatch-simd = []
 html_report = []
 
 [dependencies]
-packed_simd = { version = "0.3.1", optional = true }
+packed_simd = { version = "0.3.4", package = "packed_simd_2", optional = true }
 
 [dev-dependencies]
 quickcheck = "0.9"

--- a/src/integer_simd.rs
+++ b/src/integer_simd.rs
@@ -11,7 +11,7 @@ fn splat(byte: u8) -> usize {
 unsafe fn usize_load_unchecked(bytes: &[u8], offset: usize) -> usize {
     let mut output = 0;
     ptr::copy_nonoverlapping(
-        bytes.as_ptr().offset(offset as isize),
+        bytes.as_ptr().add(offset),
         &mut output as *mut usize as *mut u8,
         mem::size_of::<usize>()
     );

--- a/src/simd/generic.rs
+++ b/src/simd/generic.rs
@@ -95,7 +95,7 @@ pub fn chunk_num_chars(utf8_chars: &[u8]) -> usize {
 
         // 16320
         while utf8_chars.len() >= offset + 64 * 255 {
-            let mut counts = u8x64::splat(0);;
+            let mut counts = u8x64::splat(0);
             for _ in 0..255 {
                 counts -= is_leading_utf8_byte_x64(u8x64_from_offset(utf8_chars, offset));
                 offset += 64;
@@ -105,7 +105,7 @@ pub fn chunk_num_chars(utf8_chars: &[u8]) -> usize {
 
         // 8192
         if utf8_chars.len() >= offset + 64 * 128 {
-            let mut counts = u8x64::splat(0);;
+            let mut counts = u8x64::splat(0);
             for _ in 0..128 {
                 counts -= is_leading_utf8_byte_x64(u8x64_from_offset(utf8_chars, offset));
                 offset += 64;

--- a/src/simd/x86_avx2.rs
+++ b/src/simd/x86_avx2.rs
@@ -30,7 +30,7 @@ const MASK: [u8; 64] = [
 
 #[target_feature(enable = "avx2")]
 unsafe fn mm256_from_offset(slice: &[u8], offset: usize) -> __m256i {
-    _mm256_loadu_si256(slice.as_ptr().offset(offset as isize) as *const _)
+    _mm256_loadu_si256(slice.as_ptr().add(offset) as *const _)
 }
 
 #[target_feature(enable = "avx2")]


### PR DESCRIPTION
This updates the packed_simd dependency to packed_simd_2 (more on that at https://github.com/rust-lang/packed_simd/issues/298). It fixes compilation in the 0.3.4 update on recent nightly toolchains. While I was at it, I fixed some clippy lints.