### PR TITLE
Fixed overflow bug

### DIFF
--- a/src/simd/generic.rs
+++ b/src/simd/generic.rs
@@ -68,6 +68,10 @@ pub fn chunk_count(haystack: &[u8], needle: u8) -> usize {
         for i in 0..(haystack.len() - offset) / 32 {
             counts -= u8x32::from_cast(u8x32_from_offset(haystack, offset + i * 32).eq(needles_x32));
         }
+        count += sum_x32(&counts);
+
+        // Straggler; need to reset counts because prior loop can run 255 times
+        counts = u8x32::splat(0);
         if haystack.len() % 32 != 0 {
             counts -= u8x32::from_cast(u8x32_from_offset(haystack, haystack.len() - 32).eq(needles_x32)) &
                       u8x32_from_offset(&MASK, haystack.len() % 32);
@@ -118,6 +122,10 @@ pub fn chunk_num_chars(utf8_chars: &[u8]) -> usize {
         for i in 0..(utf8_chars.len() - offset) / 32 {
             counts -= is_leading_utf8_byte_x32(u8x32_from_offset(utf8_chars, offset + i * 32));
         }
+        count += sum_x32(&counts);
+
+        // Straggler; need to reset counts because prior loop can run 255 times
+        counts = u8x32::splat(0);
         if utf8_chars.len() % 32 != 0 {
             counts -= is_leading_utf8_byte_x32(u8x32_from_offset(utf8_chars, utf8_chars.len() - 32)) &
                       u8x32_from_offset(&MASK, utf8_chars.len() % 32);

--- a/tests/check.rs
+++ b/tests/check.rs
@@ -51,6 +51,16 @@ fn check_count_overflow() {
     assert_eq!(count(&haystack, needle), naive_count(&haystack, needle));
 }
 
+#[test]
+fn check_count_overflow_many() {
+    let string = [b'x'; 20000];
+    for i in 0..20000 {
+        assert_eq!(count(&string[..i], b'x'), i);
+    }
+}
+
+
+
 quickcheck! {
     fn check_num_chars_correct(haystack: Vec<u8>) -> bool {
         num_chars(&haystack) == naive_num_chars(&haystack)
@@ -74,4 +84,12 @@ fn check_num_chars_some() {
 fn check_num_chars_overflow() {
     let haystack = vec![0, 2, 3, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0];
     assert_eq!(num_chars(&haystack), naive_num_chars(&haystack));
+}
+
+#[test]
+fn check_num_chars_overflow_many() {
+    let string = [b'x'; 20000];
+    for i in 0..20000 {
+        assert_eq!(num_chars(&string[..i]), i);
+    }
 }


### PR DESCRIPTION
It's a simple overflow, because the generic SIMD code uses 512 bit vectors in some of the loops, which none of the other code does.