### PR TITLE
Switch back to packed_simd dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ runtime-dispatch-simd = []
 html_report = []
 
 [dependencies]
-packed_simd = { version = "0.3.8", package = "packed_simd_2", optional = true }
+packed_simd = { version = "0.3.8", optional = true }
 
 [dev-dependencies]
 quickcheck = "1.0"


### PR DESCRIPTION
packed_simd is apparently being published under its original name again.