### PR TITLE
remove `packed_simd` in favor of `std::simd` and `#![feature(portable_simd)]`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,12 +18,11 @@ appveyor = { repository = "llogiq/bytecount" }
 bench = false
 
 [features]
-generic-simd = ["packed_simd"]
+generic-simd = []
 runtime-dispatch-simd = []
 html_report = []
 
 [dependencies]
-packed_simd = { version = "0.3.8", optional = true }
 
 [dev-dependencies]
 quickcheck = "1.0"

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Your users can then compile with runtime dispatch using:
 cargo build --release --features runtime-dispatch-simd
 ```
 
-The second, `generic-simd`, uses `packed_simd` to provide a fast
+The second, `generic-simd`, uses [`std::simd`](https://doc.rust-lang.org/std/simd/index.html) and [`#![feature(portable_simd)]`](https://github.com/rust-lang/rust/issues/86656) to provide a fast
 architecture-agnostic SIMD codepath, but requires running on nightly.
 
 Your users can compile with this codepath using:

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -31,6 +31,8 @@
 //! [`naive_count_32`](fn.naive_count_32.html) method can be faster
 //! still on small strings.
 
+#![cfg_attr(feature = "generic-simd", feature(portable_simd))]
+
 #![deny(missing_docs)]
 #![cfg_attr(not(feature = "runtime-dispatch-simd"), no_std)]
 


### PR DESCRIPTION
Fixes #91

As mentioned in the `packed_simd` README, [the crate is superseded by `#![feature(portable_simd)]`](https://github.com/rust-lang/packed_simd#:~:text=will%20be%20superseded%20by%20%23!%5Bfeature(portable_simd)%5D.).

I'm honestly not familiar with simd or the new `std::simd` support, but I think I managed to get things working without the use of `packed_simd` (at least from local testing).