### PR TITLE
Specify rust-version and remove outdated info from README

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.32.0
+          - 1.61.0
           - stable
           - beta
           - nightly
@@ -28,7 +28,7 @@ jobs:
           - runtime-dispatch-simd
           - generic-simd
         exclude:
-        - rust: 1.32.0
+        - rust: 1.61.0
           features: generic-simd
         - rust: stable
           features: generic-simd
@@ -47,37 +47,37 @@ jobs:
           override: true
           components: clippy, rustfmt
       - uses: Swatinem/rust-cache@v2
-      - name: Build (1.32.0, default)
+      - name: Build (1.61.0, default)
         uses: actions-rs/cargo@v1.0.3
         with:
           command: build
           args: --release
-        if: ${{ matrix.features == 'default' && matrix.rust == '1.32.0' }}
-      - name: Build (1.32.0, non-default)
+        if: ${{ matrix.features == 'default' && matrix.rust == '1.61.0' }}
+      - name: Build (1.61.0, non-default)
         uses: actions-rs/cargo@v1.0.3
         with:
           command: build
           args: --release --features ${{ matrix.features }}
-        if: ${{ matrix.features != 'default' && matrix.rust == '1.32.0' }}        
+        if: ${{ matrix.features != 'default' && matrix.rust == '1.61.0' }}        
       - name: Test (default)
         uses: actions-rs/cargo@v1.0.3
         with:
           command: test
           args: --release
-        if: ${{ matrix.features == 'default' && matrix.rust != '1.32.0' }}
+        if: ${{ matrix.features == 'default' && matrix.rust != '1.61.0' }}
       - name: Test (non-default)
         uses: actions-rs/cargo@v1.0.3
         with:
           command: test
           args: --release --features ${{ matrix.features }}
-        if: ${{ matrix.features != 'default' && matrix.rust != '1.32.0' }}
+        if: ${{ matrix.features != 'default' && matrix.rust != '1.61.0' }}
       - name: bench
         uses: actions-rs/cargo@v1.0.3
         with:
           command: bench
         env:
           COUNTS: 0,10,1000,100000,10000000
-        if: ${{ matrix.rust != '1.32.0' }}
+        if: ${{ matrix.rust != '1.61.0' }}
 
   # Fails currently on check_count_overflow_many 
   #

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,8 @@
 [package]
 authors = ["Andre Bogus <bogusandre@gmail.de>", "Joshua Landau <joshua@landau.ws>"]
 description = "count occurrences of a given byte, or the number of UTF-8 code points, in a byte slice, fast"
-edition = "2018"
+edition = "2021"
+rust-version = "1.61.0"
 name = "bytecount"
 version = "0.6.9"
 license = "Apache-2.0/MIT"

--- a/README.md
+++ b/README.md
@@ -64,9 +64,6 @@ RUSTFLAGS="-C target-cpu=native" cargo build --release
 
 The scalar algorithm is explained in depth [here](https://llogiq.github.io/2016/09/27/count.html).
 
-**Note: Versions until 0.4.0 worked with Rust as of 1.20.0. Version 0.5.0 until 0.6.0 requires Rust 1.26 or later,
-and at least 1.27.2 to use SIMD. Versions from 0.6.0 require Rust 1.32.0 or later.**
-
 ## License
 
 Licensed under either of at your discretion:


### PR DESCRIPTION
The workspace does not compile with Rust 1.60.0 due to a neon target feature:

```log
error[E0658]: the target feature `neon` is currently unstable
  --> src/simd/aarch64.rs:11:18
   |
11 | #[target_feature(enable = "neon")]
   |                  ^^^^^^^^^^^^^^^
   |
   = note: see issue #44839 <https://github.com/rust-lang/rust/issues/44839> for more information
```